### PR TITLE
Finalize shop, pawn exchange, and fix gold economy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Chess variant with MOBA-style mechanics (modified pieces, neutral monsters, buff
 cd backend && python server.py
 
 # Frontend (port 3000)
+# Requires .env.local with REACT_APP_LOCAL=true (see frontend/.env.local)
 cd frontend && npm start
 
 # Tests (from project root)
@@ -77,4 +78,4 @@ See README.md roadmap for full details.
 
 Update CLAUDE.md in the same commit when changing conventions, workflow, or tech stack. For module/structure changes, update [docs/architecture.md](docs/architecture.md) instead. Bump "Last Updated" on changes.
 
-Last Updated: 2026-03-05
+Last Updated: 2026-03-06

--- a/README.md
+++ b/README.md
@@ -8,20 +8,58 @@ Roadmap is included in its own section below
 
 ## Quickstart
 
-### Prerequisites 
+### Local Development (without Docker)
+
+#### Prerequisites
+- Python 3.12 with a virtual environment
+- Node.js / npm
+- A running MongoDB instance (default: `localhost:27017`)
+
+#### Setup (first time only)
+```bash
+python3 -m venv env
+source env/bin/activate
+pip install -r backend/requirements.txt
+cd frontend && npm install
+```
+
+Create `frontend/.env.local` to point the frontend at the local backend:
+```
+REACT_APP_LOCAL=true
+```
+
+#### Running
+
+Start the backend (port 8080):
+```bash
+cd backend && python server.py
+```
+
+Start the frontend (port 3000) in a separate terminal:
+```bash
+cd frontend && npm start
+```
+
+Open http://localhost:3000 in your browser.
+
+---
+
+### Docker
+
+#### Prerequisites
 Ensure you have [Docker Desktop](docker.com) installed and opened.
 
-### Instructions
+#### Instructions
 
 (Database setup instructions to be added later...)
 
-To run locally open your terminal, navigate to the root directory of the project, and run 
+To run locally open your terminal, navigate to the root directory of the project, and run
 
 ```
 docker build . -t league-of-chess && docker run  -p 80:80 -p 8080:8080 league-of-chess
 ```
 
-You can access the game at `0.0.0.0:80` in your browser. 
+You can access the game at `0.0.0.0:80` in your browser.
 
 ### Unit Tests
 

--- a/backend/src/utils/game_scoring.py
+++ b/backend/src/utils/game_scoring.py
@@ -37,7 +37,7 @@ def update_gold_count(old_game_state: GameState, new_game_state: GameState, gold
 
     for side in new_game_state["captured_pieces"]:
         for piece in list_difference(new_game_state["captured_pieces"][side], old_game_state["captured_pieces"][side]):
-            new_game_state["gold_count"][side] += get_piece_value(piece) * 2
+            new_game_state["gold_count"][side] += 1
 
         new_game_state["gold_count"][side] -= gold_spent[side]
 

--- a/backend/src/utils/game_scoring.py
+++ b/backend/src/utils/game_scoring.py
@@ -35,7 +35,8 @@ def update_gold_count(old_game_state: GameState, new_game_state: GameState, gold
                 result.remove(item)
         return result
 
-    for side in new_game_state["captured_pieces"]:
+    for side in ["white", "black"]:
+        new_game_state["gold_count"][side] = old_game_state["gold_count"][side]
         for piece in list_difference(new_game_state["captured_pieces"][side], old_game_state["captured_pieces"][side]):
             new_game_state["gold_count"][side] += 1
 

--- a/backend/src/utils/validation.py
+++ b/backend/src/utils/validation.py
@@ -364,7 +364,7 @@ def get_gold_spent(moved_pieces: list[MovedPiece]) -> GoldSpent:
         if moved_piece["current_position"][0] is not None \
         and moved_piece["previous_position"][0] is None \
         and not any(p['previous_position'] == moved_piece["current_position"] for p in moved_pieces if p["previous_position"][0] is not None):          
-            gold_spent[moved_piece["side"]] += get_piece_value(moved_piece["piece"]["type"])
+            gold_spent[moved_piece["side"]] += get_piece_value(moved_piece["piece"]["type"]) * 2
     return gold_spent
 
 

--- a/backend/tests/integration/test_api_bishop_mechanics.py
+++ b/backend/tests/integration/test_api_bishop_mechanics.py
@@ -107,10 +107,9 @@ def test_full_bishop_debuff_capture(game):
         "position": [6, 0],
         "type": "black_pawn"
     })
-    game_on_next_turn["gold_count"]["white"] += 2
     game_state = api.GameStateRequest(**game_on_next_turn)
     game = api.update_game_state(game["id"], game_state, Response())
-    
+
     current_energize_stack_value = game["board_state"][5][1][0]["energize_stacks"]
     energize_stack_difference = current_energize_stack_value - original_energize_stack_value
 
@@ -176,10 +175,9 @@ def test_full_bishop_debuff_adjacent_application(game):
         "position": [7, 1],
         "type": "black_knight"
     })
-    game_on_next_turn["gold_count"]["white"] += 6
     game_state = api.GameStateRequest(**game_on_next_turn)
     game = api.update_game_state(game["id"], game_state, Response())
-    
+
     assert not game["board_state"][7][1]
     assert game["board_state"][6][0][0]["type"] == "black_pawn"
     assert game["board_state"][5][1][0]["type"] == "white_bishop"
@@ -246,10 +244,9 @@ def test_multiple_full_bishop_debuffs(game):
         "position": [6, 0],
         "type": "black_pawn"
     })
-    game_on_next_turn["gold_count"]["white"] += 2
     game_state = api.GameStateRequest(**game_on_next_turn)
     game = api.update_game_state(game["id"], game_state, Response())
-    
+
     current_energize_stack_value = game["board_state"][5][1][0]["energize_stacks"]
     energize_stack_difference = current_energize_stack_value - original_energize_stack_value
 
@@ -268,7 +265,6 @@ def test_multiple_full_bishop_debuffs(game):
         "position": [6, 2],
         "type": "black_pawn"
     })
-    game_on_next_turn["gold_count"]["white"] += 2
     game_state = api.GameStateRequest(**game_on_next_turn)
     game = api.update_game_state(game["id"], game_state, Response())
     

--- a/backend/tests/integration/test_api_piece_buying.py
+++ b/backend/tests/integration/test_api_piece_buying.py
@@ -77,21 +77,21 @@ def test_buying_kings_and_queens_should_not_be_allowed(game):
 
 def test_buying_pieces(game):
     pieces = {
-        "pawn": 1,
-        "knight": 3,
-        "bishop": 3,
-        "rook": 5
+        "pawn": 2,
+        "knight": 6,
+        "bishop": 6,
+        "rook": 10
     }
     for piece in pieces:
         game = clear_game(game)
         game_on_next_turn = copy.deepcopy(game)
-        
+
         game_on_next_turn['board_state'][0][0] = [{"type": "black_king"}]
         game_on_next_turn['board_state'][7][7] = [{"type": "white_king"}]
         game_on_next_turn['board_state'][6][7] = [{"type": "white_pawn", "pawn_buff": 0}]
         game_on_next_turn['board_state'][1][0] = [{"type": "black_pawn", "pawn_buff": 0}]
 
-        game_on_next_turn["gold_count"] = {"white": 5, "black": 5}
+        game_on_next_turn["gold_count"] = {"white": 12, "black": 12}
 
         game_state = api.GameStateRequest(**game_on_next_turn)
         game = api.update_game_state_no_restrictions(game["id"], game_state, Response())
@@ -102,7 +102,7 @@ def test_buying_pieces(game):
         game_state = api.GameStateRequest(**game_on_next_turn)
         game = api.update_game_state(game["id"], game_state, Response())
 
-        assert game["gold_count"]["white"] == 5 - pieces[piece]
+        assert game["gold_count"]["white"] == 12 - pieces[piece]
 
         # black
         game_on_next_turn = copy.deepcopy(game)
@@ -110,26 +110,26 @@ def test_buying_pieces(game):
         game_state = api.GameStateRequest(**game_on_next_turn)
         game = api.update_game_state(game["id"], game_state, Response(), player=False)
 
-        assert game["gold_count"]["black"] == 5 - pieces[piece]
+        assert game["gold_count"]["black"] == 12 - pieces[piece]
 
 
 def test_buying_pieces_when_it_is_not_your_turn_not_allowed(game):
     pieces = {
-        "pawn": 1,
-        "knight": 3,
-        "bishop": 3,
-        "rook": 5
+        "pawn": 2,
+        "knight": 6,
+        "bishop": 6,
+        "rook": 10
     }
     for piece in pieces:
         game = clear_game(game)
         game_on_next_turn = copy.deepcopy(game)
-        
+
         game_on_next_turn['board_state'][0][0] = [{"type": "black_king"}]
         game_on_next_turn['board_state'][7][7] = [{"type": "white_king"}]
         game_on_next_turn['board_state'][6][7] = [{"type": "white_pawn", "pawn_buff": 0}]
         game_on_next_turn['board_state'][1][0] = [{"type": "black_pawn", "pawn_buff": 0}]
 
-        game_on_next_turn["gold_count"] = {"white": 5, "black": 5}
+        game_on_next_turn["gold_count"] = {"white": 12, "black": 12}
 
         game_state = api.GameStateRequest(**game_on_next_turn)
         game = api.update_game_state_no_restrictions(game["id"], game_state, Response())

--- a/backend/tests/unit/test_gold_spent.py
+++ b/backend/tests/unit/test_gold_spent.py
@@ -1,0 +1,107 @@
+import copy
+from src.utils.validation import get_gold_spent
+from src.utils.game_scoring import update_gold_count
+
+
+def _make_moved_piece(piece_type, side, previous_position, current_position):
+    return {
+        "piece": {"type": piece_type},
+        "side": side,
+        "previous_position": previous_position,
+        "current_position": current_position,
+    }
+
+
+def test_gold_spent_for_spawned_pawn():
+    moved_pieces = [
+        _make_moved_piece("white_pawn", "white", [None, None], [5, 4]),
+    ]
+    gold_spent = get_gold_spent(moved_pieces)
+    assert gold_spent == {"white": 2, "black": 0}
+
+
+def test_gold_spent_for_spawned_knight():
+    moved_pieces = [
+        _make_moved_piece("white_knight", "white", [None, None], [5, 4]),
+    ]
+    gold_spent = get_gold_spent(moved_pieces)
+    assert gold_spent == {"white": 6, "black": 0}
+
+
+def test_gold_spent_for_spawned_bishop():
+    moved_pieces = [
+        _make_moved_piece("white_bishop", "white", [None, None], [5, 4]),
+    ]
+    gold_spent = get_gold_spent(moved_pieces)
+    assert gold_spent == {"white": 6, "black": 0}
+
+
+def test_gold_spent_for_spawned_rook():
+    moved_pieces = [
+        _make_moved_piece("white_rook", "white", [None, None], [5, 4]),
+    ]
+    gold_spent = get_gold_spent(moved_pieces)
+    assert gold_spent == {"white": 10, "black": 0}
+
+
+def test_gold_spent_for_spawned_queen():
+    moved_pieces = [
+        _make_moved_piece("white_queen", "white", [None, None], [5, 4]),
+    ]
+    gold_spent = get_gold_spent(moved_pieces)
+    assert gold_spent == {"white": 18, "black": 0}
+
+
+def test_no_gold_spent_for_normal_move():
+    moved_pieces = [
+        _make_moved_piece("white_pawn", "white", [6, 4], [5, 4]),
+    ]
+    gold_spent = get_gold_spent(moved_pieces)
+    assert gold_spent == {"white": 0, "black": 0}
+
+
+def test_no_gold_spent_when_no_pieces_moved():
+    gold_spent = get_gold_spent([])
+    assert gold_spent == {"white": 0, "black": 0}
+
+
+def _make_game_state(captured_pieces, gold_count):
+    return {
+        "captured_pieces": captured_pieces,
+        "gold_count": copy.deepcopy(gold_count),
+    }
+
+
+def test_capture_gives_1_gold_for_pawn():
+    old = _make_game_state({"white": [], "black": []}, {"white": 0, "black": 0})
+    new = _make_game_state({"white": ["black_pawn"], "black": []}, {"white": 0, "black": 0})
+    update_gold_count(old, new, {"white": 0, "black": 0})
+    assert new["gold_count"] == {"white": 1, "black": 0}
+
+
+def test_capture_gives_1_gold_for_queen():
+    old = _make_game_state({"white": [], "black": []}, {"white": 0, "black": 0})
+    new = _make_game_state({"white": ["black_queen"], "black": []}, {"white": 0, "black": 0})
+    update_gold_count(old, new, {"white": 0, "black": 0})
+    assert new["gold_count"] == {"white": 1, "black": 0}
+
+
+def test_capture_gives_1_gold_for_rook():
+    old = _make_game_state({"white": [], "black": []}, {"white": 0, "black": 0})
+    new = _make_game_state({"white": ["black_rook"], "black": []}, {"white": 0, "black": 0})
+    update_gold_count(old, new, {"white": 0, "black": 0})
+    assert new["gold_count"] == {"white": 1, "black": 0}
+
+
+def test_multiple_captures_give_1_gold_each():
+    old = _make_game_state({"white": [], "black": []}, {"white": 0, "black": 0})
+    new = _make_game_state({"white": ["black_pawn", "black_knight"], "black": []}, {"white": 0, "black": 0})
+    update_gold_count(old, new, {"white": 0, "black": 0})
+    assert new["gold_count"] == {"white": 2, "black": 0}
+
+
+def test_capture_gold_and_shop_deduction_combined():
+    old = _make_game_state({"white": [], "black": []}, {"white": 5, "black": 0})
+    new = _make_game_state({"white": ["black_pawn"], "black": []}, {"white": 5, "black": 0})
+    update_gold_count(old, new, {"white": 2, "black": 0})
+    assert new["gold_count"] == {"white": 4, "black": 0}  # 5 + 1 capture - 2 shop

--- a/frontend/src/components/Background.js
+++ b/frontend/src/components/Background.js
@@ -1,3 +1,20 @@
+// Background.js — SHOP PLACEMENT REWORK NEEDED
+// ==============================================
+// Contains the board squares and piece placement logic for shop purchases.
+//
+// TODO - PLACEMENT UX REWORK:
+//   - The green "Select Position" buttons (lines 128-144) are small and hard to find
+//   - Instead: highlight valid squares with a colored overlay or pulsing border
+//     when a shop piece is selected (similar to how PossibleMove dots work)
+//   - Consider showing a ghost/transparent preview of the piece on hover
+//   - Add placement confirmation or undo option
+//
+// TODO - VALIDATION:
+//   - isValidSquare() (lines 40-64) restricts to rows 4-7, avoids bosses/sword/occupied
+//   - Backend also validates but currently no location restriction to king's starting
+//     square — this may need discussion (rules say king buys at starting square,
+//     but placement can be anywhere on your half?)
+
 import React, { useState } from 'react';
 import '../index.css';
 

--- a/frontend/src/components/Background.js
+++ b/frontend/src/components/Background.js
@@ -1,33 +1,17 @@
-// Background.js — SHOP PLACEMENT REWORK NEEDED
-// ==============================================
-// Contains the board squares and piece placement logic for shop purchases.
-//
-// TODO - PLACEMENT UX REWORK:
-//   - The green "Select Position" buttons (lines 128-144) are small and hard to find
-//   - Instead: highlight valid squares with a colored overlay or pulsing border
-//     when a shop piece is selected (similar to how PossibleMove dots work)
-//   - Consider showing a ghost/transparent preview of the piece on hover
-//   - Add placement confirmation or undo option
-//
-// TODO - VALIDATION:
-//   - isValidSquare() (lines 40-64) restricts to rows 4-7, avoids bosses/sword/occupied
-//   - Backend also validates but currently no location restriction to king's starting
-//     square — this may need discussion (rules say king buys at starting square,
-//     but placement can be anywhere on your half?)
-
 import React, { useState } from 'react';
 import '../index.css';
 
 import { GameStateContextData }  from '../context/GameStateContext';
 
-import { 
-    determineBackgroundColor, 
-    determineColor, 
+import {
+    determineBackgroundColor,
+    determineColor,
     determineIsMobile,
-    DRAGON_POSITION, 
-    BOARD_HERALD_POSITION, 
+    DRAGON_POSITION,
+    BOARD_HERALD_POSITION,
     BARON_NASHOR_POSITION,
     PLAYERS,
+    IMAGE_MAP,
     camelToSnake,
     getPiecePrice
 } from '../utility';
@@ -124,17 +108,20 @@ const Square = (props) => {
         }
     }
 
+    const [isHovering, setIsHovering] = useState(false)
+    const showHighlight = props.shopPieceSelected && isValidSquare(row, col)
+
     return (
-        <div 
-            style={{ backgroundColor }} 
+        <div
+            style={{ backgroundColor, position: 'relative' }}
             className="square"
             onClick={() => handleSquareClick()}
         >
-            <p 
+            <p
                 style={{ color, fontSize: "1vw", opacity: col === 0 ? 1 : 0 }}
                 className='label' >{8-row}</p>
-            <p 
-                style={{ 
+            <p
+                style={{
                     color,
                     alignSelf: "flex-end",
                     fontSize: "1vw",
@@ -142,23 +129,22 @@ const Square = (props) => {
                 }}
                 className='label'
             >{String.fromCharCode(97 + col)}</p>
-            {
-                props.shopPieceSelected && 
-                isValidSquare(row, col) &&
-                <button
-                    onClick={() => handleSquareSelectionClick()}
-                    style={{
-                        fontSize: `${isMobile ? 1: 0.5}vw`,
-                        height: `${isMobile ? 5: 1.75}vw`,
-                        position: "relative",
-                        right: `${isMobile ? 2.5: 1.8}vw`,
-                        top: `${isMobile ? 1: 0.5}vw`,
-                        borderRadius: `${isMobile ? 1: 0.5}vw`,
-                        borderColor: "green",
-                        backgroundColor: "green",
-                        padding: `${isMobile ? 0.5 : 0}vw ${isMobile ? 0.75: 0.375}vw`
-                    }}
-                >Select Position</button>}
+            {showHighlight && (
+                <div
+                    className="valid-square-highlight"
+                    onClick={(e) => { e.stopPropagation(); handleSquareSelectionClick(); }}
+                    onMouseEnter={() => setIsHovering(true)}
+                    onMouseLeave={() => setIsHovering(false)}
+                />
+            )}
+            {showHighlight && isHovering && (
+                <img
+                    src={IMAGE_MAP[props.shopPieceSelected]}
+                    className="ghost-piece"
+                    alt="preview"
+                    style={{ width: `${isMobile ? 3.6 : 1.8}vw` }}
+                />
+            )}
         </div>
     )
 }

--- a/frontend/src/components/Background.js
+++ b/frontend/src/components/Background.js
@@ -6,7 +6,7 @@ import { GameStateContextData }  from '../context/GameStateContext';
 import {
     determineBackgroundColor,
     determineColor,
-    determineIsMobile,
+    useIsMobile,
     DRAGON_POSITION,
     BOARD_HERALD_POSITION,
     BARON_NASHOR_POSITION,
@@ -35,7 +35,7 @@ const Square = (props) => {
 
     const backgroundColor = determineBackgroundColor(row, col, positionInPlay, possibleCaptures, isDragonActive, isHeraldActive, isBaronActive, swordInTheStonePosition)
     const color = determineColor(row, col, isDragonActive, isHeraldActive, isBaronActive)
-    const isMobile = determineIsMobile()
+    const isMobile = useIsMobile()
 
     const isValidSquare = (row, col) => {
         if (row <= 3) {

--- a/frontend/src/components/Background.js
+++ b/frontend/src/components/Background.js
@@ -12,8 +12,7 @@ import {
     BARON_NASHOR_POSITION,
     PLAYERS,
     IMAGE_MAP,
-    camelToSnake,
-    getPiecePrice
+    camelToSnake
 } from '../utility';
 
 const isBossActive = (boardState, bossPosition, bossType) => {
@@ -57,7 +56,7 @@ const Square = (props) => {
             return false
         }
 
-        if (boardState[row][col]) {
+        if (boardState[row][col]?.length) {
             return false
         }
     
@@ -66,22 +65,17 @@ const Square = (props) => {
 
     const handleSquareSelectionClick = () => {
         const newBoardState = [...gameState.boardState]
-        const selectedShopPieceValue = getPiecePrice(props.shopPieceSelected)
-        var newGoldCount = {...gameState.goldCount}
 
-        if (!newBoardState[row][col]) {
+        if (!newBoardState[row][col]?.length) {
             newBoardState[row][col] = [{"type": camelToSnake(props.shopPieceSelected)}]
         } else {
             // player shouldn't be allowed to place piece where another piece is present
             return
         }
 
-        newGoldCount[PLAYERS[0]] -= selectedShopPieceValue ? selectedShopPieceValue : 0
-        
         gameState.updateGameState({
-            ...gameState, 
+            ...gameState,
             boardState: newBoardState,
-            goldCount: newGoldCount
         })
         props.setShopPieceSelected(null)
     }
@@ -142,7 +136,7 @@ const Square = (props) => {
                     src={IMAGE_MAP[props.shopPieceSelected]}
                     className="ghost-piece"
                     alt="preview"
-                    style={{ width: `${isMobile ? 3.6 : 1.8}vw` }}
+                    style={{ width: `${isMobile ? 3.6 : 1.8}vw`, height: `${isMobile ? 5.9 : 2.95}vw` }}
                 />
             )}
         </div>

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import Background from './Background';
 import Piece from './Piece';
@@ -8,6 +8,7 @@ import CapturedPieces from './CapturedPieces';
 import HUD from './HUD';
 import Victory from './Victory';
 import Defeat from './Defeat';
+import PawnExchangeModal from './PawnExchangeModal';
 
 
 import { GameStateContextData }  from '../context/GameStateContext';
@@ -22,11 +23,33 @@ const Board = () => {
     const possibleMoves = gameState.possibleMoves
     const possibleCaptures = gameState.possibleCaptures
     const swordInTheStonePosition = gameState.swordInTheStonePosition
+    const turnCount = gameState.turnCount
     const isMobile = determineIsMobile()
     const blackDefeat = gameState.blackDefeat
     const whiteDefeat = gameState.whiteDefeat
 
     const [shopPieceSelected, setShopPieceSelected] = useState(null)
+    const [pawnExchangePosition, setPawnExchangePosition] = useState(null)
+
+    useEffect(() => {
+        if (turnCount <= 0) {
+            setPawnExchangePosition(null)
+            return
+        }
+        if (possibleMoves.length === 0 && possibleCaptures.length === 0) {
+            for (let col = 0; col < 8; col++) {
+                const square = boardState[0]?.[col]
+                if (square) {
+                    const whitePawn = square.find(piece => piece.type === "white_pawn")
+                    if (whitePawn) {
+                        setPawnExchangePosition([0, col])
+                        return
+                    }
+                }
+            }
+        }
+        setPawnExchangePosition(null)
+    }, [boardState, possibleMoves, possibleCaptures, turnCount])
 
     return(
         <div style={isMobile ? {display: "block", margin: "auto"}: null}>
@@ -99,6 +122,13 @@ const Board = () => {
                     <Victory isMobile={isMobile}/> : whiteDefeat ?
                     <Defeat isMobile={isMobile}/> : null
                 }
+                {pawnExchangePosition && (
+                    <PawnExchangeModal
+                        pawnPosition={pawnExchangePosition}
+                        side={PLAYERS[0]}
+                        onExchange={() => setPawnExchangePosition(null)}
+                    />
+                )}
             </div>
             <HUD 
                 shopPieceSelected={shopPieceSelected}

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -39,7 +39,7 @@ const Board = () => {
         if (possibleMoves.length === 0 && possibleCaptures.length === 0) {
             for (let col = 0; col < 8; col++) {
                 const square = boardState[0]?.[col]
-                if (square) {
+                if (square?.length) {
                     const whitePawn = square.find(piece => piece.type === "white_pawn")
                     if (whitePawn) {
                         setPawnExchangePosition([0, col])

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -13,7 +13,7 @@ import PawnExchangeModal from './PawnExchangeModal';
 
 import { GameStateContextData }  from '../context/GameStateContext';
 
-import { PLAYERS, pickSide, snakeToCamel, determineIsMobile } from '../utility';
+import { PLAYERS, pickSide, snakeToCamel, useIsMobile } from '../utility';
 
 const Board = () => {
     // positionInPlay used to figure out what piece is being moved by player
@@ -24,7 +24,7 @@ const Board = () => {
     const possibleCaptures = gameState.possibleCaptures
     const swordInTheStonePosition = gameState.swordInTheStonePosition
     const turnCount = gameState.turnCount
-    const isMobile = determineIsMobile()
+    const isMobile = useIsMobile()
     const blackDefeat = gameState.blackDefeat
     const whiteDefeat = gameState.whiteDefeat
 

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -74,9 +74,9 @@ const Board = () => {
                                                     <Piece
                                                         side={pickSide(piece.type)}
                                                         key={[row, col]}
-                                                        row={row} 
+                                                        row={row}
                                                         col={col}
-                                                        inPlay={positionInPlay[0] === row && positionInPlay[1] === col} 
+                                                        inPlay={positionInPlay[0] === row && positionInPlay[1] === col}
                                                         type={snakeToCamel(piece.type)}
                                                         pawnBuff={piece.pawn_buff}
                                                         energizeStacks={piece.energize_stacks}
@@ -84,6 +84,7 @@ const Board = () => {
                                                         bishopDebuff={piece.bishop_debuff}
                                                         checkProtection={piece.check_protection}
                                                         health={piece.health}
+                                                        shopPieceSelected={shopPieceSelected}
                                                     />
                                                 );
                                         }));

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -95,7 +95,7 @@ const Board = () => {
                                     // a position is represented as an array
                                     // [[position that piece in play will land in , position of enemy in danger], ...]
                                     if (!possibleCaptures.some((possibleCapture) => JSON.stringify(possibleMove).includes(JSON.stringify(possibleCapture[0]))))
-                                        if (!shopPieceSelected || (possibleMove[0] <= 3)) {
+                                        if (!shopPieceSelected) {
                                             return(
                                                 <PossibleMove 
                                                     key={'pm' + possibleMove[0].toString() + possibleMove[1].toString()}

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -65,15 +65,15 @@ const Board = () => {
                 {
                     boardState.map((pieceRow, row) => {
                         return (
-                            <div>
+                            <div key={row}>
                                 {pieceRow.map((piece_array, col) => {
                                     if (piece_array?.length) {
                                         return(
-                                            piece_array.map((piece) => {
+                                            piece_array.map((piece, i) => {
                                                 return (
                                                     <Piece
                                                         side={pickSide(piece.type)}
-                                                        key={[row, col]}
+                                                        key={`${row}-${col}-${i}`}
                                                         row={row}
                                                         col={col}
                                                         inPlay={positionInPlay[0] === row && positionInPlay[1] === col}

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -67,7 +67,7 @@ const Board = () => {
                         return (
                             <div>
                                 {pieceRow.map((piece_array, col) => {
-                                    if (piece_array) {  
+                                    if (piece_array?.length) {
                                         return(
                                             piece_array.map((piece) => {
                                                 return (

--- a/frontend/src/components/Buff.js
+++ b/frontend/src/components/Buff.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { IMAGE_MAP, determineIsMobile } from '../utility';
+import { IMAGE_MAP, useIsMobile } from '../utility';
 import  { GameStateContextData }  from '../context/GameStateContext';
 
 const Buff = (props) => {
     const gameState = GameStateContextData()
-    const isMobile = determineIsMobile()
+    const isMobile = useIsMobile()
     const topPosition = props.row * 3.8 * (isMobile ? 2: 1)
     const leftPosition = props.col * 3.7 * (isMobile ? 2: 1)
 

--- a/frontend/src/components/CapturedPieces.js
+++ b/frontend/src/components/CapturedPieces.js
@@ -24,7 +24,7 @@ const CapturedPieces = (props) => {
             })}
             {
                 capturePointAdvantage?.[0] === props.side ?
-                    <p>Point Advantage: {capturePointAdvantage[1]}</p>
+                    <p>Point Advantage: {Math.round(capturePointAdvantage[1] * 10) / 10}</p>
                 : null
             }
         </div>

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -16,7 +16,8 @@ const HUD = (props) => {
         setToggleShop(!toggleShop)
     }
 
-    const isKingOnHomeSquare = gameState.boardState[7][4]?.[0].type === "white_king"
+    const isWhiteTurn = turnCount % 2 === 0
+    const isKingOnHomeSquare = gameState.boardState[7][4]?.[0]?.type === "white_king"
     return(
         <div>
             <div style={{
@@ -34,7 +35,7 @@ const HUD = (props) => {
                     marginBottom: `${isMobile ? 1 : 0.5}vw`
                 }}>
                     <span style={{ fontSize: `${isMobile ? 2.5 : 1.25}vw` }}>Turn: {turnCount}</span>
-                    {isKingOnHomeSquare ?
+                    {isWhiteTurn && isKingOnHomeSquare ?
                         <button
                             className="pixel-btn"
                             onClick={() => handleShopButtonClick()}

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
-import { IMAGE_MAP, PLAYERS, determineIsMobile } from '../utility';
+import { IMAGE_MAP, PLAYERS, useIsMobile } from '../utility';
 import Shop from './Shop';
 
 
@@ -9,7 +9,7 @@ const HUD = (props) => {
     const turnCount = gameState.turnCount
     const goldCount = gameState.goldCount?.[PLAYERS[0]] || 0
     const enemyGoldCount = gameState.goldCount?.[PLAYERS[1]] || 0
-    const isMobile = determineIsMobile()
+    const isMobile = useIsMobile()
     const [toggleShop, setToggleShop] = useState(false)
 
     const handleShopButtonClick = () => {
@@ -26,7 +26,9 @@ const HUD = (props) => {
                 padding: `${isMobile ? 1.5 : 0.75}vw ${isMobile ? 2 : 1}vw`,
                 fontFamily: 'Basic',
                 color: 'white',
-                marginTop: `${isMobile ? 1 : 0.5}vw`
+                marginTop: `${isMobile ? 1 : 0.5}vw`,
+                width: isMobile ? '59.2vw' : '29.6vw',
+                boxSizing: 'border-box'
             }}>
                 <div style={{
                     display: 'flex',

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -1,3 +1,14 @@
+// HUD.js — REWORK NEEDED
+// =======================
+// Heads-up display: turn counter + shop toggle.
+//
+// TODO - VISUAL REWORK:
+//   - Turn counter should use pixel font, maybe framed in a pixel art panel
+//   - Shop Open/Close button should be a pixel art icon (chest, store sign, etc.)
+//     instead of a plain green/red HTML button
+//   - Consider adding gold count display here too (always visible, not just in shop)
+//   - Layout should feel like a game HUD bar, not a plain div with text
+
 import React, {useState} from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
 import Shop from './Shop';

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
 import { IMAGE_MAP, PLAYERS, useIsMobile } from '../utility';
 import Shop from './Shop';
@@ -18,6 +18,13 @@ const HUD = (props) => {
 
     const isWhiteTurn = turnCount % 2 === 0
     const isKingOnHomeSquare = gameState.boardState[7][4]?.[0]?.type === "white_king"
+
+    useEffect(() => {
+        if (!isWhiteTurn || !isKingOnHomeSquare) {
+            setToggleShop(false)
+            props.setShopPieceSelected(null)
+        }
+    }, [isWhiteTurn, isKingOnHomeSquare])
     return(
         <div>
             <div style={{

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -1,22 +1,15 @@
-// HUD.js — REWORK NEEDED
-// =======================
-// Heads-up display: turn counter + shop toggle.
-//
-// TODO - VISUAL REWORK:
-//   - Turn counter should use pixel font, maybe framed in a pixel art panel
-//   - Shop Open/Close button should be a pixel art icon (chest, store sign, etc.)
-//     instead of a plain green/red HTML button
-//   - Consider adding gold count display here too (always visible, not just in shop)
-//   - Layout should feel like a game HUD bar, not a plain div with text
-
 import React, {useState} from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
+import { IMAGE_MAP, PLAYERS, determineIsMobile } from '../utility';
 import Shop from './Shop';
 
 
 const HUD = (props) => {
     const gameState = GameStateContextData()
     const turnCount = gameState.turnCount
+    const goldCount = gameState.goldCount?.[PLAYERS[0]] || 0
+    const enemyGoldCount = gameState.goldCount?.[PLAYERS[1]] || 0
+    const isMobile = determineIsMobile()
     const [toggleShop, setToggleShop] = useState(false)
 
     const handleShopButtonClick = () => {
@@ -26,24 +19,61 @@ const HUD = (props) => {
     const isKingOnHomeSquare = gameState.boardState[7][4]?.[0].type === "white_king"
     return(
         <div>
-            <h3># of Turns: {turnCount}</h3>
-            {isKingOnHomeSquare ? 
-                <button 
-                    onClick={() => handleShopButtonClick()}
-                    style={{
-                        backgroundColor: toggleShop ? "red": "green",
-                        borderColor: toggleShop ? "red": "green",
-                        borderRadius: "0.5vw"
-                    }}    
-                >{toggleShop ? "Close": "Open"} Shop</button>:
-                null
-            }
+            <div style={{
+                backgroundColor: 'rgb(71, 33, 1)',
+                border: `${isMobile ? 0.4 : 0.2}vw solid rgb(50, 23, 0)`,
+                padding: `${isMobile ? 1.5 : 0.75}vw ${isMobile ? 2 : 1}vw`,
+                fontFamily: 'Basic',
+                color: 'white',
+                marginTop: `${isMobile ? 1 : 0.5}vw`
+            }}>
+                <div style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    marginBottom: `${isMobile ? 1 : 0.5}vw`
+                }}>
+                    <span style={{ fontSize: `${isMobile ? 2.5 : 1.25}vw` }}>Turn: {turnCount}</span>
+                    {isKingOnHomeSquare ?
+                        <button
+                            className="pixel-btn"
+                            onClick={() => handleShopButtonClick()}
+                            style={{
+                                fontSize: `${isMobile ? 1.8 : 0.9}vw`,
+                                padding: `${isMobile ? 0.6 : 0.3}vw ${isMobile ? 1.5 : 0.75}vw`,
+                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                            }}
+                        >{toggleShop ? "Close Shop" : "Open Shop"}</button> :
+                        null
+                    }
+                </div>
+                <div style={{ display: 'flex', gap: `${isMobile ? 3 : 1.5}vw`, alignItems: 'center' }}>
+                    <div className="gold-display" style={{ fontSize: `${isMobile ? 2 : 1}vw` }}>
+                        <span style={{ color: 'rgb(230, 233, 198)' }}>You:</span>
+                        <img
+                            src={IMAGE_MAP["goldCoin"]}
+                            alt="gold"
+                            style={{ height: `${isMobile ? 2.5 : 1.25}vw` }}
+                        />
+                        <span style={{ color: 'rgb(230, 233, 198)' }}>{goldCount}</span>
+                    </div>
+                    <div className="gold-display" style={{ fontSize: `${isMobile ? 2 : 1}vw`, opacity: 0.7 }}>
+                        <span style={{ color: 'rgb(180, 180, 180)' }}>Enemy:</span>
+                        <img
+                            src={IMAGE_MAP["goldCoin"]}
+                            alt="enemy gold"
+                            style={{ height: `${isMobile ? 2.5 : 1.25}vw`, filter: 'grayscale(100%)' }}
+                        />
+                        <span style={{ color: 'rgb(180, 180, 180)' }}>{enemyGoldCount}</span>
+                    </div>
+                </div>
+            </div>
             {
                 toggleShop ?
-                 <Shop 
+                 <Shop
                     shopPieceSelected={props.shopPieceSelected}
                     setShopPieceSelected={props.setShopPieceSelected}
-                 /> : 
+                 /> :
                  null
             }
         </div>

--- a/frontend/src/components/PawnExchangeModal.js
+++ b/frontend/src/components/PawnExchangeModal.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
-import { IMAGE_MAP, PROMOTION_PIECES, camelToSnake, determineIsMobile } from '../utility';
+import { IMAGE_MAP, PROMOTION_PIECES, camelToSnake, useIsMobile } from '../utility';
 
 const PawnExchangeModal = (props) => {
     const gameState = GameStateContextData()
-    const isMobile = determineIsMobile()
+    const isMobile = useIsMobile()
 
     const handleSelection = (pieceType) => {
         const newBoardState = [...gameState.boardState]

--- a/frontend/src/components/PawnExchangeModal.js
+++ b/frontend/src/components/PawnExchangeModal.js
@@ -1,50 +1,78 @@
-// PawnExchangeModal.js
-// ====================
-// Pawn promotion UI — shown when a pawn reaches the back rank.
-//
-// HOW TO DETECT WHEN TO SHOW:
-//   The backend does NOT send an explicit "exchange required" flag.
-//   Instead, it signals implicitly:
-//     1. A pawn of the current side exists on the promotion rank
-//        (row 0 for white, row 7 for black)
-//     2. possible_moves and possible_captures are BOTH empty arrays
-//     3. The turn count has been reset (same side still moving)
-//   Check for: pawn on back rank + no legal moves = show this modal.
-//
-// WHAT IT DOES:
-//   1. Display 4 promotion options: Knight, Bishop, Rook, Queen
-//      (King exchange is rejected by the backend — validation.py:289-293)
-//   2. Each option shows the piece sprite (use IMAGE_MAP from utility.js)
-//   3. On selection:
-//      a. Replace the pawn in boardState with the chosen piece at same position
-//      b. Call updateGameState() to send to backend
-//      c. Backend validates via check_if_pawn_exchange_is_possibly_being_carried_out()
-//      d. Turn count increments, game continues
-//
-// STYLING:
-//   - Pixel art retro aesthetic — brown/earth tones matching Shop.js palette
-//     (rgb(125, 59, 2) background, rgb(71, 33, 1) border)
-//   - Use the pixel font already in the project
-//   - Modal overlay centered on the board, semi-transparent backdrop
-//   - Piece sprites should be large enough to tap on mobile (use determineIsMobile())
-//   - Header like "~ Promote Pawn ~" matching Shop.js "~ Shop ~" style
-//
-// PROPS (suggested):
-//   - pawnPosition: [row, col] — position of the pawn being promoted
-//   - side: "white" — determines piece type prefix (currently only white plays)
-//   - onExchange: callback after exchange completes (to clear modal state)
-//
-// WHERE TO RENDER:
-//   Board.js — add detection logic and render this modal when conditions are met.
-//   It should block all other board interaction while visible.
-//
-// RELEVANT BACKEND FILES:
-//   - validation.py:315-332 — check_if_pawn_exchange_is_required()
-//   - validation.py:335-349 — check_if_pawn_exchange_is_possibly_being_carried_out()
-//   - game_update_pipeline.py:148-167 — handle_pawn_exchanges()
-//   - moves_and_positions.py:46-48 — clears moves when exchange required
-//
-// RELEVANT FRONTEND FILES:
-//   - utility.js — IMAGE_MAP, camelToSnake, determineIsMobile
-//   - context/GameStateContext.js — updateGameState, boardState, possibleMoves
-//   - components/Board.js — parent component, detection logic goes here
+import React from 'react';
+import { GameStateContextData } from '../context/GameStateContext';
+import { IMAGE_MAP, PROMOTION_PIECES, camelToSnake, determineIsMobile } from '../utility';
+
+const PawnExchangeModal = (props) => {
+    const gameState = GameStateContextData()
+    const isMobile = determineIsMobile()
+
+    const handleSelection = (pieceType) => {
+        const newBoardState = [...gameState.boardState]
+        const [row, col] = props.pawnPosition
+        newBoardState[row][col] = [{ "type": camelToSnake(props.side + pieceType) }]
+
+        gameState.updateGameState({
+            ...gameState,
+            boardState: newBoardState
+        })
+        props.onExchange()
+    }
+
+    return (
+        <div className="modal-overlay">
+            <div
+                className="pixel-panel"
+                style={{
+                    width: `${isMobile ? 40 : 20}vw`,
+                    padding: `${isMobile ? 2 : 1}vw`,
+                    textAlign: 'center'
+                }}
+            >
+                <p style={{
+                    fontFamily: 'Basic',
+                    fontSize: `${isMobile ? 3 : 1.5}vw`,
+                    margin: `0 0 ${isMobile ? 1.5 : 0.75}vw 0`
+                }}>~ Promote Pawn ~</p>
+                <div style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    gap: `${isMobile ? 2 : 1}vw`
+                }}>
+                    {PROMOTION_PIECES.map((piece) => (
+                        <div
+                            key={piece}
+                            onClick={() => handleSelection(piece)}
+                            style={{
+                                cursor: 'pointer',
+                                padding: `${isMobile ? 1 : 0.5}vw`,
+                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`,
+                                border: `${isMobile ? 0.4 : 0.2}vw solid rgb(71, 33, 1)`,
+                                backgroundColor: 'rgb(194, 164, 115)',
+                                display: 'flex',
+                                flexDirection: 'column',
+                                alignItems: 'center'
+                            }}
+                        >
+                            <img
+                                src={IMAGE_MAP[props.side + piece]}
+                                alt={piece}
+                                style={{
+                                    width: `${isMobile ? 8 : 4}vw`,
+                                    imageRendering: 'pixelated'
+                                }}
+                            />
+                            <p style={{
+                                fontFamily: 'Basic',
+                                fontSize: `${isMobile ? 1.5 : 0.75}vw`,
+                                margin: `${isMobile ? 0.5 : 0.25}vw 0 0 0`,
+                                color: 'rgb(71, 33, 1)'
+                            }}>{piece}</p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default PawnExchangeModal;

--- a/frontend/src/components/PawnExchangeModal.js
+++ b/frontend/src/components/PawnExchangeModal.js
@@ -9,7 +9,12 @@ const PawnExchangeModal = (props) => {
     const handleSelection = (pieceType) => {
         const newBoardState = [...gameState.boardState]
         const [row, col] = props.pawnPosition
-        newBoardState[row][col] = [{ "type": camelToSnake(props.side + pieceType) }]
+        const square = [...(newBoardState[row][col] || [])]
+        const pawnIndex = square.findIndex(p => p.type === `${props.side}_pawn`)
+        if (pawnIndex !== -1) {
+            square[pawnIndex] = { "type": camelToSnake(props.side + pieceType) }
+        }
+        newBoardState[row][col] = square
 
         gameState.updateGameState({
             ...gameState,

--- a/frontend/src/components/PawnExchangeModal.js
+++ b/frontend/src/components/PawnExchangeModal.js
@@ -1,0 +1,50 @@
+// PawnExchangeModal.js
+// ====================
+// Pawn promotion UI — shown when a pawn reaches the back rank.
+//
+// HOW TO DETECT WHEN TO SHOW:
+//   The backend does NOT send an explicit "exchange required" flag.
+//   Instead, it signals implicitly:
+//     1. A pawn of the current side exists on the promotion rank
+//        (row 0 for white, row 7 for black)
+//     2. possible_moves and possible_captures are BOTH empty arrays
+//     3. The turn count has been reset (same side still moving)
+//   Check for: pawn on back rank + no legal moves = show this modal.
+//
+// WHAT IT DOES:
+//   1. Display 4 promotion options: Knight, Bishop, Rook, Queen
+//      (King exchange is rejected by the backend — validation.py:289-293)
+//   2. Each option shows the piece sprite (use IMAGE_MAP from utility.js)
+//   3. On selection:
+//      a. Replace the pawn in boardState with the chosen piece at same position
+//      b. Call updateGameState() to send to backend
+//      c. Backend validates via check_if_pawn_exchange_is_possibly_being_carried_out()
+//      d. Turn count increments, game continues
+//
+// STYLING:
+//   - Pixel art retro aesthetic — brown/earth tones matching Shop.js palette
+//     (rgb(125, 59, 2) background, rgb(71, 33, 1) border)
+//   - Use the pixel font already in the project
+//   - Modal overlay centered on the board, semi-transparent backdrop
+//   - Piece sprites should be large enough to tap on mobile (use determineIsMobile())
+//   - Header like "~ Promote Pawn ~" matching Shop.js "~ Shop ~" style
+//
+// PROPS (suggested):
+//   - pawnPosition: [row, col] — position of the pawn being promoted
+//   - side: "white" — determines piece type prefix (currently only white plays)
+//   - onExchange: callback after exchange completes (to clear modal state)
+//
+// WHERE TO RENDER:
+//   Board.js — add detection logic and render this modal when conditions are met.
+//   It should block all other board interaction while visible.
+//
+// RELEVANT BACKEND FILES:
+//   - validation.py:315-332 — check_if_pawn_exchange_is_required()
+//   - validation.py:335-349 — check_if_pawn_exchange_is_possibly_being_carried_out()
+//   - game_update_pipeline.py:148-167 — handle_pawn_exchanges()
+//   - moves_and_positions.py:46-48 — clears moves when exchange required
+//
+// RELEVANT FRONTEND FILES:
+//   - utility.js — IMAGE_MAP, camelToSnake, determineIsMobile
+//   - context/GameStateContext.js — updateGameState, boardState, possibleMoves
+//   - components/Board.js — parent component, detection logic goes here

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -8,7 +8,6 @@ import {
     MAX_BOSS_HEALTH, 
     determineIsMobile, 
     snakeToCamel,
-    getPiecePrice,
     camelToSnake
 } from '../utility';
 
@@ -31,28 +30,21 @@ const Piece = (props) => {
             const newPositionInPlay = [null, null]
             const pieceInPlay = newBoardState[positionInPlay[0]][positionInPlay[1]].find(piece => piece.type.includes(PLAYERS[0]))
             const newCapturedPieces = {...gameState.capturedPieces}
-            var newGoldCount = {...gameState.goldCount}
-            var capturedPiece
-            var capturedPieceValue
 
             for (let i = 0; i < newBoardState[props.row][props.col]?.length; i++) {
                 if (snakeToCamel(newBoardState[props.row][props.col][i]?.type) === type) {
-                    capturedPiece = newBoardState[props.row][props.col][i]
-                    capturedPieceValue = getPiecePrice(snakeToCamel(capturedPiece.type))
-                    newCapturedPieces[PLAYERS[0]].push(capturedPiece.type)
+                    newCapturedPieces[PLAYERS[0]].push(newBoardState[props.row][props.col][i].type)
                     newBoardState[props.row][props.col].splice(i, 1);
                 }
             }
-            newGoldCount[PLAYERS[0]] += capturedPieceValue ? capturedPieceValue : 0
 
             newBoardState[props.row][props.col] = newBoardState[props.row][props.col].filter(piece => !piece.type.includes(PLAYERS[1]))
             newBoardState[props.row][props.col].push(pieceInPlay)
             newBoardState[positionInPlay[0]][positionInPlay[1]] = newBoardState[positionInPlay[0]][positionInPlay[1]]?.filter(piece => piece.type !== pieceInPlay.type)
 
             gameState.updateGameState({
-                ...gameState, 
+                ...gameState,
                 capturedPieces: newCapturedPieces,
-                goldCount: newGoldCount,
                 boardState: newBoardState,
                 positionInPlay: newPositionInPlay
             })
@@ -140,34 +132,27 @@ const Piece = (props) => {
     const handleCaptureButtonClick = () => {
         const newBoardState = [...gameState.boardState]
         const newCapturedPieces = {...gameState.capturedPieces}
-        var newGoldCount = {...gameState.goldCount}
-        var capturedPiece
-        var capturedPieceValue
-        var i = 0 
+        var i = 0
         while (i < newBoardState[props.row][props.col]?.length) {
             if (snakeToCamel(newBoardState[props.row][props.col][i]?.type) === props.type) {
-                capturedPiece = newBoardState[props.row][props.col][i]
-                capturedPieceValue = getPiecePrice(snakeToCamel(capturedPiece.type))
-                newCapturedPieces[PLAYERS[0]].push(capturedPiece.type)
+                newCapturedPieces[PLAYERS[0]].push(newBoardState[props.row][props.col][i].type)
                 newBoardState[props.row][props.col].splice(i, 1);
             }
             i++
         }
-        
+
         const newBishopSpecialCaptures = [
             {
                 position: [props.row, props.col],
-                type: camelToSnake(props.type) 
+                type: camelToSnake(props.type)
             }
         ]
-        
-        newGoldCount[PLAYERS[0]] += capturedPieceValue ? capturedPieceValue : 0
+
         gameState.updateGameState({
-            ...gameState, 
+            ...gameState,
             bishopSpecialCaptures: newBishopSpecialCaptures,
             boardState: newBoardState,
             capturedPieces: newCapturedPieces,
-            goldCount: newGoldCount
         })
         
     }
@@ -179,7 +164,8 @@ const Piece = (props) => {
         if (props.type.toLowerCase().includes('nashor')) return 'nashor_piece'
     }
 
-    const image_src = props.pawnBuff ? props.type + `${props.pawnBuff + 1}` : props.type
+    const buffedSrc = props.pawnBuff ? props.type + `${props.pawnBuff + 1}` : props.type
+    const image_src = IMAGE_MAP[buffedSrc] ? buffedSrc : props.type
 
     return(
         <div>

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -6,7 +6,7 @@ import {
     PLAYERS, 
     IMAGE_MAP, 
     MAX_BOSS_HEALTH, 
-    determineIsMobile, 
+    useIsMobile, 
     snakeToCamel,
     camelToSnake
 } from '../utility';
@@ -14,7 +14,7 @@ import {
 const Piece = (props) => {
     const gameState = GameStateContextData()
     const positionInPlay = gameState.positionInPlay
-    const isMobile = determineIsMobile()
+    const isMobile = useIsMobile()
     const topPosition = props.row * 3.7 * (isMobile ? 2: 1)
     const leftPosition = props.col * 3.7 * (isMobile ? 2: 1)
 

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -19,6 +19,8 @@ const Piece = (props) => {
     const leftPosition = props.col * 3.7 * (isMobile ? 2: 1)
 
     const handlePieceClick = () => {
+        if (props.shopPieceSelected) return
+
         const isNeutralPiecePresent = () => {
             if (props.side === "neutral") return true
             const square = gameState.boardState[props.row]?.[props.col] || []

--- a/frontend/src/components/PieceShopModal.js
+++ b/frontend/src/components/PieceShopModal.js
@@ -5,7 +5,7 @@ import { IMAGE_MAP, getPiecePrice } from '../utility';
 const PieceShopModal = (props) => {
 
     const price = getPiecePrice(props.type)
-    const canAfford = props.playerGoldCount >= price
+    const canAfford = props.projectedGoldCount >= price
     const isSelected = props.shopPieceSelected === props.type
 
     const handleCardClick = () => {

--- a/frontend/src/components/PieceShopModal.js
+++ b/frontend/src/components/PieceShopModal.js
@@ -1,3 +1,19 @@
+// PieceShopModal.js — REWORK NEEDED
+// ==================================
+// Individual piece card in the shop. Currently a plain image + button.
+//
+// TODO - VISUAL REWORK:
+//   - Style as a pixel art "item card" — bordered frame, maybe parchment texture
+//   - Piece sprite should be centered and larger
+//   - Price tag should look like a pixel coin + number label, not a blue HTML button
+//   - Unaffordable pieces should be greyed out with a lock/X overlay, not just opacity
+//   - Selected piece should have a visible highlight (glow, border color change)
+//   - Piece name label ("Pawn", "Knight", etc.) should use the pixel font
+//
+// TODO - UX:
+//   - Clicking an already-selected piece should deselect it (toggle behavior)
+//   - Consider hover tooltip showing piece abilities / value
+
 import React, {useState} from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
 import { IMAGE_MAP, getPiecePrice } from '../utility';

--- a/frontend/src/components/PieceShopModal.js
+++ b/frontend/src/components/PieceShopModal.js
@@ -23,7 +23,6 @@ const PieceShopModal = (props) => {
             className={cardClasses}
             onClick={handleCardClick}
             style={{
-                cursor: canAfford ? 'pointer' : 'not-allowed',
                 position: 'relative',
                 width: `${props.isMobile ? 10 : 5}vw`,
                 marginRight: `${props.isMobile ? 1.5 : 0.75}vw`,
@@ -34,10 +33,11 @@ const PieceShopModal = (props) => {
                 <img
                     src={IMAGE_MAP[props.type]}
                     alt={props.type}
+                    draggable={false}
                     style={{
                         width: `${props.isMobile ? 8 : 4}vw`,
                         display: 'block',
-                        imageRendering: 'pixelated'
+                        imageRendering: 'pixelated',
                     }}
                 />
                 {!canAfford && (
@@ -53,7 +53,6 @@ const PieceShopModal = (props) => {
                         fontFamily: 'Basic',
                         fontWeight: 'bold',
                         textShadow: '2px 2px 0 black',
-                        pointerEvents: 'none'
                     }}>X</div>
                 )}
             </div>
@@ -61,17 +60,20 @@ const PieceShopModal = (props) => {
                 fontFamily: 'Basic',
                 fontSize: `${props.isMobile ? 1.5 : 0.75}vw`,
                 margin: `${props.isMobile ? 0.4 : 0.2}vw 0`,
-                color: 'rgb(71, 33, 1)'
+                color: 'rgb(71, 33, 1)',
             }}>{props.type.replace("white", "")}</p>
             <div className="gold-display" style={{
                 justifyContent: 'center',
                 fontSize: `${props.isMobile ? 1.2 : 0.6}vw`,
-                color: 'rgb(71, 33, 1)'
+                color: 'rgb(71, 33, 1)',
             }}>
                 <img
                     src={IMAGE_MAP["goldCoin"]}
                     alt="gold"
-                    style={{ height: `${props.isMobile ? 1.5 : 0.75}vw` }}
+                    draggable={false}
+                    style={{
+                        height: `${props.isMobile ? 1.5 : 0.75}vw`,
+                    }}
                 />
                 <span>{price}</span>
             </div>

--- a/frontend/src/components/PieceShopModal.js
+++ b/frontend/src/components/PieceShopModal.js
@@ -1,21 +1,4 @@
-// PieceShopModal.js — REWORK NEEDED
-// ==================================
-// Individual piece card in the shop. Currently a plain image + button.
-//
-// TODO - VISUAL REWORK:
-//   - Style as a pixel art "item card" — bordered frame, maybe parchment texture
-//   - Piece sprite should be centered and larger
-//   - Price tag should look like a pixel coin + number label, not a blue HTML button
-//   - Unaffordable pieces should be greyed out with a lock/X overlay, not just opacity
-//   - Selected piece should have a visible highlight (glow, border color change)
-//   - Piece name label ("Pawn", "Knight", etc.) should use the pixel font
-//
-// TODO - UX:
-//   - Clicking an already-selected piece should deselect it (toggle behavior)
-//   - Consider hover tooltip showing piece abilities / value
-
-import React, {useState} from 'react';
-import { GameStateContextData } from '../context/GameStateContext';
+import React from 'react';
 import { IMAGE_MAP, getPiecePrice } from '../utility';
 
 
@@ -23,57 +6,74 @@ const PieceShopModal = (props) => {
 
     const price = getPiecePrice(props.type)
     const canAfford = props.playerGoldCount >= price
+    const isSelected = props.shopPieceSelected === props.type
 
-    const pieceShopModalStyle = {
-        width: `${props.isMobile ? 8: 4}vw`,
-        marginRight: `${props.isMobile ? 4: 2}vw`,
-        marginLeft: props.type === "whitePawn" ? `${props.isMobile ? 5: 2.5}vw`: 0,
-        opacity: canAfford ? 1: 0.5
-    }
-    const pieceShopTitle = {
-        marginLeft: props.type === "whitePawn" ? `${props.isMobile ? 5.7: 2.85}vw`: 0,
-        fontSize: `${props.isMobile ? 2: 1}vw`,
-        opacity: canAfford ? 1: 0.5
+    const handleCardClick = () => {
+        if (isSelected) {
+            props.setShopPieceSelected(null)
+        } else if (canAfford) {
+            props.setShopPieceSelected(props.type)
+        }
     }
 
-    const handleBuyButtonClick = () => {
-        console.log(`Buying ${props.type.replace("white", "")}`)
-        props.setShopPieceSelected(props.type)
-    }
+    const cardClasses = `piece-card${isSelected ? ' piece-card-selected' : ''}${!canAfford ? ' piece-card-locked' : ''}`
 
     return(
-        <div>
-            <img
-                src={IMAGE_MAP[props.type]}
-                style={pieceShopModalStyle}
-            /> 
-            <p 
-                style={{...pieceShopTitle, marginBottom: `${props.isMobile ? 0.4: 0.2}vw`}}
-            >{props.type.replace("white", "")}</p>
-            <div style={{display: "flex"}}>
-                
-                <button  
-                    disabled={!canAfford} 
+        <div
+            className={cardClasses}
+            onClick={handleCardClick}
+            style={{
+                cursor: canAfford ? 'pointer' : 'not-allowed',
+                position: 'relative',
+                width: `${props.isMobile ? 10 : 5}vw`,
+                marginRight: `${props.isMobile ? 1.5 : 0.75}vw`,
+                marginLeft: props.type === "whitePawn" ? `${props.isMobile ? 2 : 1}vw` : 0,
+            }}
+        >
+            <div style={{ position: 'relative' }}>
+                <img
+                    src={IMAGE_MAP[props.type]}
+                    alt={props.type}
                     style={{
-                        ...pieceShopTitle,
-                        marginLeft: props.type === "whitePawn" ? `${props.isMobile ? 4.6: 2.3}vw`: 0,
-                        marginTop: `${props.isMobile ? 1: 0.5}vw`,
-                        marginBottom: `${props.isMobile ? 8: 4}vw`,
-                        fontSize: `${props.isMobile ? 1.2: 0.6}vw`,
-                        borderRadius: `${props.isMobile ? 1: 0.5}vw`,
-                        backgroundColor: "rgb(102, 216, 242)",
-                        borderColor: "rgb(150, 216, 242)"
+                        width: `${props.isMobile ? 8 : 4}vw`,
+                        display: 'block',
+                        imageRendering: 'pixelated'
                     }}
-                    onClick={() => handleBuyButtonClick()}
-                >
-                    <img 
-                        src={IMAGE_MAP["goldCoin"]}
-                        style={{
-                            opacity: canAfford ? 1: 0.5, 
-                            marginRight: `${props.isMobile ? 0.2: 0.2}vw`,
-                            height: `${props.isMobile ? 1.5: 0.75}vw`,
-                        }} 
-                    />{price} Gold</button>
+                />
+                {!canAfford && (
+                    <div style={{
+                        position: 'absolute',
+                        top: 0, left: 0, right: 0, bottom: 0,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        paddingTop: '85%',
+                        fontSize: `${props.isMobile ? 9 : 4.5}vw`,
+                        color: 'rgb(220, 30, 30)',
+                        fontFamily: 'Basic',
+                        fontWeight: 'bold',
+                        textShadow: '2px 2px 0 black',
+                        pointerEvents: 'none'
+                    }}>X</div>
+                )}
+            </div>
+            <p style={{
+                fontFamily: 'Basic',
+                fontSize: `${props.isMobile ? 1.5 : 0.75}vw`,
+                margin: `${props.isMobile ? 0.4 : 0.2}vw 0`,
+                color: 'rgb(71, 33, 1)'
+            }}>{props.type.replace("white", "")}</p>
+            <div className="gold-display" style={{
+                justifyContent: 'center',
+                fontSize: `${props.isMobile ? 1.2 : 0.6}vw`,
+                color: 'rgb(71, 33, 1)'
+            }}>
+                <img
+                    src={IMAGE_MAP["goldCoin"]}
+                    alt="gold"
+                    style={{ height: `${props.isMobile ? 1.5 : 0.75}vw` }}
+                />
+                <span>{price}</span>
             </div>
         </div>
     );

--- a/frontend/src/components/PossibleMove.js
+++ b/frontend/src/components/PossibleMove.js
@@ -2,11 +2,11 @@ import React, { useState } from 'react';
 
 import  { GameStateContextData }  from '../context/GameStateContext';
 
-import { determineIsMobile } from '../utility';
+import { useIsMobile } from '../utility';
 
 const PossibleMove = (props) => {
     const gameState = GameStateContextData()
-    const isMobile = determineIsMobile()
+    const isMobile = useIsMobile()
     const topPosition = props.row * 3.7 * (isMobile ? 2: 1)
     const leftPosition = props.col * 3.7 * (isMobile ? 2: 1)
     const [isMouseOverSquare, setIsMouseOverSquare] = useState(false)

--- a/frontend/src/components/Rules.js
+++ b/frontend/src/components/Rules.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useState } from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
-import { IMAGE_MAP, determineIsMobile } from '../utility';
+import { IMAGE_MAP, useIsMobile } from '../utility';
 import GeneralRules from './GeneralRules';
 import PawnRules from './PawnRules';
 import KnightRules from './KnightRules';
@@ -14,7 +14,7 @@ const Rules = () => {
     const gameState = GameStateContextData()
     const boardState = gameState.boardState
     const positionInPlay = gameState.positionInPlay
-    const isMobile = determineIsMobile()
+    const isMobile = useIsMobile()
 
     return(
         <div

--- a/frontend/src/components/Shop.js
+++ b/frontend/src/components/Shop.js
@@ -33,7 +33,8 @@ const Shop = (props) => {
                 display: "flex",
                 justifyContent: "center",
                 padding: `${isMobile ? 2 : 1}vw 0`,
-                borderBottom: `${isMobile ? 0.3 : 0.15}vw solid rgb(71, 33, 1)`
+                borderBottom: `${isMobile ? 0.3 : 0.15}vw solid rgb(71, 33, 1)`,
+                cursor: playerGoldCount < 2 ? 'not-allowed' : 'default'
             }}>
                 <PieceShopModal
                     type="whitePawn"

--- a/frontend/src/components/Shop.js
+++ b/frontend/src/components/Shop.js
@@ -6,7 +6,8 @@ import PieceShopModal from './PieceShopModal';
 
 const Shop = (props) => {
     const gameState = GameStateContextData()
-    const playerGoldCount = gameState.goldCount[PLAYERS[0]] - (getPiecePrice(props.shopPieceSelected) || 0)
+    const currentGold = gameState.goldCount[PLAYERS[0]]
+    const projectedGoldCount = currentGold - (getPiecePrice(props.shopPieceSelected) || 0)
     const isMobile = useIsMobile()
 
     return(
@@ -35,32 +36,32 @@ const Shop = (props) => {
                 justifyContent: "center",
                 padding: `${isMobile ? 2 : 1}vw 0`,
                 borderBottom: `${isMobile ? 0.3 : 0.15}vw solid rgb(71, 33, 1)`,
-                cursor: playerGoldCount < 2 ? 'not-allowed' : 'default'
+                cursor: projectedGoldCount < 2 ? 'not-allowed' : 'default'
             }}>
                 <PieceShopModal
                     type="whitePawn"
-                    playerGoldCount={playerGoldCount}
+                    projectedGoldCount={projectedGoldCount}
                     isMobile={isMobile}
                     shopPieceSelected={props.shopPieceSelected}
                     setShopPieceSelected={props.setShopPieceSelected}
                 />
                 <PieceShopModal
                     type="whiteKnight"
-                    playerGoldCount={playerGoldCount}
+                    projectedGoldCount={projectedGoldCount}
                     isMobile={isMobile}
                     shopPieceSelected={props.shopPieceSelected}
                     setShopPieceSelected={props.setShopPieceSelected}
                 />
                 <PieceShopModal
                     type="whiteBishop"
-                    playerGoldCount={playerGoldCount}
+                    projectedGoldCount={projectedGoldCount}
                     isMobile={isMobile}
                     shopPieceSelected={props.shopPieceSelected}
                     setShopPieceSelected={props.setShopPieceSelected}
                 />
                 <PieceShopModal
                     type="whiteRook"
-                    playerGoldCount={playerGoldCount}
+                    projectedGoldCount={projectedGoldCount}
                     isMobile={isMobile}
                     shopPieceSelected={props.shopPieceSelected}
                     setShopPieceSelected={props.setShopPieceSelected}
@@ -78,7 +79,7 @@ const Shop = (props) => {
                         alt="gold"
                         style={{ height: `${isMobile ? 3 : 1.5}vw` }}
                     />
-                    <span>{playerGoldCount} Gold</span>
+                    <span>{projectedGoldCount} Gold</span>
                 </div>
                 {props.shopPieceSelected && (
                     <button

--- a/frontend/src/components/Shop.js
+++ b/frontend/src/components/Shop.js
@@ -1,21 +1,22 @@
 import React from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
-import { IMAGE_MAP, PLAYERS, getPiecePrice, determineIsMobile } from '../utility';
+import { IMAGE_MAP, PLAYERS, getPiecePrice, useIsMobile } from '../utility';
 import PieceShopModal from './PieceShopModal';
 
 
 const Shop = (props) => {
     const gameState = GameStateContextData()
     const playerGoldCount = gameState.goldCount[PLAYERS[0]] - (getPiecePrice(props.shopPieceSelected) || 0)
-    const isMobile = determineIsMobile()
+    const isMobile = useIsMobile()
 
     return(
         <div
             className="pixel-panel"
             style={{
-                width: `${isMobile ? 55 : 27.15}vw`,
+                width: `${isMobile ? 59.2 : 29.6}vw`,
                 marginTop: `${isMobile ? 3 : 1.5}vw`,
                 borderWidth: `${isMobile ? 2.5 : 1.25}vw`,
+                boxSizing: 'border-box',
             }}
         >
             <div style={{

--- a/frontend/src/components/Shop.js
+++ b/frontend/src/components/Shop.js
@@ -1,30 +1,4 @@
-// Shop.js — REWORK NEEDED
-// ========================
-// Current state: functional but visually basic. Needs pixel art retro overhaul.
-//
-// TODO - VISUAL REWORK:
-//   - Replace plain HTML button/text styling with pixel art aesthetic
-//   - Add a pixel art shop counter / storefront backdrop
-//   - Piece sprites should sit on a shelf or display stand, not just float
-//   - Gold display should feel like a coin counter (pixel coin sprites, not just text)
-//   - "~ Shop ~" title could be a pixel art banner or sign
-//   - Consider a shopkeeper character sprite for personality
-//   - Close/Open button in HUD.js should also match the retro theme
-//
-// TODO - UX IMPROVEMENTS:
-//   - Show piece placement preview on the board when a piece is selected
-//   - Add a "Cancel" option to deselect a piece without placing it
-//   - Visual feedback when purchase completes (gold deduction animation, etc.)
-//   - Error state if backend rejects placement (currently no error handling)
-//   - Consider showing which squares are valid for placement while piece is selected
-//     (currently handled in Background.js via isValidSquare but the green buttons
-//      are not very discoverable)
-//
-// NOTE: The buy flow itself works — PieceShopModal sets the selected piece,
-// Background.js handles placement and sends the state update to the backend.
-// Only the visual presentation needs reworking.
-
-import React, { useState } from 'react';
+import React from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
 import { IMAGE_MAP, PLAYERS, getPiecePrice, determineIsMobile } from '../utility';
 import PieceShopModal from './PieceShopModal';
@@ -37,38 +11,52 @@ const Shop = (props) => {
 
     return(
         <div
-            className="shop"
+            className="pixel-panel"
             style={{
-                width: `${isMobile ? 55: 27.15}vw`,
-                marginTop: `${isMobile ? 3: 1.5}vw`,
-                border: `${isMobile ? 2.5: 1.25}vw solid rgb(71, 33, 1)`,
-                backgroundColor: "rgb(125, 59, 2)"
+                width: `${isMobile ? 55 : 27.15}vw`,
+                marginTop: `${isMobile ? 3 : 1.5}vw`,
+                borderWidth: `${isMobile ? 2.5 : 1.25}vw`,
             }}
         >
-            <p style={{fontSize: `${isMobile ? 3: 1.5}vw`, marginTop: `${isMobile ? 5: 2.5}vw`, textAlign: "center"}}>~ Shop ~</p>
-            <div style={{display: "flex"}}>
-                <PieceShopModal 
+            <div style={{
+                backgroundColor: 'rgb(71, 33, 1)',
+                padding: `${isMobile ? 1 : 0.5}vw 0`,
+                textAlign: 'center'
+            }}>
+                <p style={{
+                    fontFamily: 'Basic',
+                    fontSize: `${isMobile ? 3 : 1.5}vw`,
+                    margin: 0
+                }}>~ Shop ~</p>
+            </div>
+            <div style={{
+                display: "flex",
+                justifyContent: "center",
+                padding: `${isMobile ? 2 : 1}vw 0`,
+                borderBottom: `${isMobile ? 0.3 : 0.15}vw solid rgb(71, 33, 1)`
+            }}>
+                <PieceShopModal
                     type="whitePawn"
                     playerGoldCount={playerGoldCount}
                     isMobile={isMobile}
                     shopPieceSelected={props.shopPieceSelected}
                     setShopPieceSelected={props.setShopPieceSelected}
                 />
-                <PieceShopModal 
+                <PieceShopModal
                     type="whiteKnight"
                     playerGoldCount={playerGoldCount}
                     isMobile={isMobile}
                     shopPieceSelected={props.shopPieceSelected}
                     setShopPieceSelected={props.setShopPieceSelected}
                 />
-                <PieceShopModal 
+                <PieceShopModal
                     type="whiteBishop"
                     playerGoldCount={playerGoldCount}
                     isMobile={isMobile}
                     shopPieceSelected={props.shopPieceSelected}
                     setShopPieceSelected={props.setShopPieceSelected}
                 />
-                <PieceShopModal 
+                <PieceShopModal
                     type="whiteRook"
                     playerGoldCount={playerGoldCount}
                     isMobile={isMobile}
@@ -76,21 +64,32 @@ const Shop = (props) => {
                     setShopPieceSelected={props.setShopPieceSelected}
                 />
             </div>
-            <div style={{display: "flex", marginBottom: `${isMobile ? 1 : 0.5}vw`}}>
-                <img 
-                    src={IMAGE_MAP["goldCoin"]}
-                    style={{
-                        height: `${isMobile ? 3 : 1.5}vw`,
-                        marginLeft: `${isMobile ? 1.5 : 0.75}vw`,
-                        marginRight: `${isMobile ? 1: 0.5}vw`
-                    }}
-                />
-                <p style={{
-                    fontSize: `${isMobile ? 2 : 1}vw`,
-                    margin: 0,
-                }}>{playerGoldCount} Gold</p>
+            <div style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                padding: `${isMobile ? 1 : 0.5}vw ${isMobile ? 1.5 : 0.75}vw`
+            }}>
+                <div className="gold-display" style={{ fontSize: `${isMobile ? 2 : 1}vw` }}>
+                    <img
+                        src={IMAGE_MAP["goldCoin"]}
+                        alt="gold"
+                        style={{ height: `${isMobile ? 3 : 1.5}vw` }}
+                    />
+                    <span>{playerGoldCount} Gold</span>
+                </div>
+                {props.shopPieceSelected && (
+                    <button
+                        className="pixel-btn"
+                        onClick={() => props.setShopPieceSelected(null)}
+                        style={{
+                            fontSize: `${isMobile ? 1.5 : 0.75}vw`,
+                            padding: `${isMobile ? 0.5 : 0.25}vw ${isMobile ? 1 : 0.5}vw`,
+                            borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                        }}
+                    >Cancel</button>
+                )}
             </div>
-            
         </div>
     );
 }

--- a/frontend/src/components/Shop.js
+++ b/frontend/src/components/Shop.js
@@ -1,3 +1,29 @@
+// Shop.js — REWORK NEEDED
+// ========================
+// Current state: functional but visually basic. Needs pixel art retro overhaul.
+//
+// TODO - VISUAL REWORK:
+//   - Replace plain HTML button/text styling with pixel art aesthetic
+//   - Add a pixel art shop counter / storefront backdrop
+//   - Piece sprites should sit on a shelf or display stand, not just float
+//   - Gold display should feel like a coin counter (pixel coin sprites, not just text)
+//   - "~ Shop ~" title could be a pixel art banner or sign
+//   - Consider a shopkeeper character sprite for personality
+//   - Close/Open button in HUD.js should also match the retro theme
+//
+// TODO - UX IMPROVEMENTS:
+//   - Show piece placement preview on the board when a piece is selected
+//   - Add a "Cancel" option to deselect a piece without placing it
+//   - Visual feedback when purchase completes (gold deduction animation, etc.)
+//   - Error state if backend rejects placement (currently no error handling)
+//   - Consider showing which squares are valid for placement while piece is selected
+//     (currently handled in Background.js via isValidSquare but the green buttons
+//      are not very discoverable)
+//
+// NOTE: The buy flow itself works — PieceShopModal sets the selected piece,
+// Background.js handles placement and sends the state update to the backend.
+// Only the visual presentation needs reworking.
+
 import React, { useState } from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
 import { IMAGE_MAP, PLAYERS, getPiecePrice, determineIsMobile } from '../utility';

--- a/frontend/src/components/Title.js
+++ b/frontend/src/components/Title.js
@@ -1,11 +1,13 @@
 import React from 'react';
+import { useIsMobile } from '../utility';
 
 
 const Title = () => {
+    const isMobile = useIsMobile()
 
     return(
         <div>
-            <div className="title">
+            <div className="title" style={{ textAlign: isMobile ? 'center' : 'left' }}>
                 <h1 style={{display: "inline"}}>Chess</h1>
                 <h6 style={{display: "inline"}}>patch 1.1</h6>
                 <hr style={{clear:"both"}}/>

--- a/frontend/src/context/GameStateContext.js
+++ b/frontend/src/context/GameStateContext.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from "react"
+import { createContext, useContext, useEffect, useRef, useState } from "react"
 import { PLAYERS, BASE_API_URL, convertKeysToCamelCase, convertKeysToSnakeCase } from '../utility';
 
 const GameStateContext = createContext({
@@ -68,6 +68,7 @@ export function GameStateProvider({children}) {
                 updateGameState: updateGameState
             }
             setGameState(parsedJsonResponse)
+            sessionStorage.setItem("lastUpdated", parsedJsonResponse["lastUpdated"])
         })
         .catch(exception => {
             console.log(exception);
@@ -123,13 +124,15 @@ export function GameStateProvider({children}) {
     }
     const [gameState, setGameState] = useState(initGameState);
 
-    const [intervalTime, setIntervalTime] = useState(3000);
-    
+    const fetchInProgress = useRef(false)
+
     const fetchGameState = () => {
+        if (fetchInProgress.current) return
+        fetchInProgress.current = true
+
         var url
         var method
         const gameStateId = sessionStorage.getItem("gameStateId")
-        const lastUpdated = sessionStorage.getItem("lastUpdated")
 
         if (gameStateId == null) {
             url = `${BASE_API_URL}/api/game`
@@ -137,11 +140,6 @@ export function GameStateProvider({children}) {
         } else {
             url = `${BASE_API_URL}/api/game/${gameStateId}`
             method = "GET"
-        }
-        
-        const sixSecondsAgo = Date.now() - 6000;
-        if (Date.parse(lastUpdated) < sixSecondsAgo) {
-            return
         }
 
         fetch(url, {"method": method})
@@ -159,9 +157,11 @@ export function GameStateProvider({children}) {
             setGameState(parsedResult)
             sessionStorage.setItem("gameStateId", parsedResult["id"])
             sessionStorage.setItem("lastUpdated", parsedResult["lastUpdated"])
+            fetchInProgress.current = false
         })
         .catch(exception => {
             console.log(exception);
+            fetchInProgress.current = false
         });
     }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -154,7 +154,7 @@ button {
     display: flex;
     flex-direction: column;
     align-items: center;
-    border-radius: 0.3vw;
+    cursor: pointer;
 }
 
 .piece-card-selected {
@@ -165,6 +165,7 @@ button {
 .piece-card-locked {
     filter: grayscale(100%);
     opacity: 0.6;
+    cursor: not-allowed;
 }
 
 .gold-display {
@@ -272,7 +273,6 @@ progress {
     .piece-card {
         border-width: 0.4vw;
         padding: 1vw;
-        border-radius: 0.6vw;
     }
 
     .piece-card-selected {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -90,6 +90,90 @@ button {
     border-color: black
 }
 
+.pixel-panel {
+    background-color: rgb(125, 59, 2);
+    border: 0.2vw solid rgb(71, 33, 1);
+    color: white;
+    font-family: "Basic";
+    image-rendering: pixelated;
+}
+
+.pixel-btn {
+    font-family: "Basic";
+    background-color: rgb(101, 67, 33);
+    color: white;
+    border: 0.2vw solid rgb(71, 33, 1);
+    cursor: pointer;
+    image-rendering: pixelated;
+}
+
+.pixel-btn:hover {
+    background-color: rgb(140, 90, 40);
+}
+
+.modal-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 100;
+}
+
+.valid-square-highlight {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(100, 200, 100, 0.35);
+    border: 0.15vw solid rgba(100, 200, 100, 0.7);
+    cursor: pointer;
+    box-sizing: border-box;
+}
+
+.ghost-piece {
+    position: absolute;
+    opacity: 0.5;
+    pointer-events: none;
+    z-index: 10;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.piece-card {
+    background-color: rgb(194, 164, 115);
+    border: 0.2vw solid rgb(71, 33, 1);
+    padding: 0.5vw;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    border-radius: 0.3vw;
+}
+
+.piece-card-selected {
+    border-color: rgb(255, 215, 0);
+    box-shadow: 0 0 0.5vw rgb(255, 215, 0);
+}
+
+.piece-card-locked {
+    filter: grayscale(100%);
+    opacity: 0.6;
+}
+
+.gold-display {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3vw;
+    font-family: "Basic";
+}
+
 /* For Firefox */
 progress::-moz-progress-bar {
     background: red;
@@ -173,22 +257,48 @@ progress {
         flex-direction: column;
     }
     
+    .pixel-panel {
+        border-width: 0.4vw;
+    }
+
+    .pixel-btn {
+        border-width: 0.4vw;
+    }
+
+    .valid-square-highlight {
+        border-width: 0.3vw;
+    }
+
+    .piece-card {
+        border-width: 0.4vw;
+        padding: 1vw;
+        border-radius: 0.6vw;
+    }
+
+    .piece-card-selected {
+        box-shadow: 0 0 1vw rgb(255, 215, 0);
+    }
+
+    .gold-display {
+        gap: 0.6vw;
+    }
+
     /* For Firefox */
     progress::-moz-progress-bar {
         background: red;
         font-size: 0.5vw;
     }
-    
+
     /* For Chrome or Safari */
     progress::-webkit-progress-value {
         background: red;
         font-size: 0.5vw;
     }
-    
+
     /* For IE10 */
     progress {
         background: red;
         font-size: 0.5vw;
     }
-    
+
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -141,7 +141,7 @@ button {
     opacity: 0.5;
     pointer-events: none;
     z-index: 10;
-    top: 50%;
+    top: 35%;
     left: 50%;
     transform: translate(-50%, -50%);
 }

--- a/frontend/src/utility.js
+++ b/frontend/src/utility.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 const PLAYERS = ["white", "black"]
 const PROMOTION_PIECES = ["Knight", "Bishop", "Rook", "Queen"]
 
@@ -329,7 +331,16 @@ function findThreateningBishop(boardState, side, row, col) {
     return null;
   }
 
-const determineIsMobile = () => window.matchMedia("(max-width: 1024px)").matches && window.matchMedia("(orientation: portrait)").matches
+const useIsMobile = () => {
+    const query = window.matchMedia("(max-width: 1024px) and (orientation: portrait)")
+    const [isMobile, setIsMobile] = React.useState(query.matches)
+    React.useEffect(() => {
+        const handler = (e) => setIsMobile(e.matches)
+        query.addEventListener('change', handler)
+        return () => query.removeEventListener('change', handler)
+    }, [])
+    return isMobile
+}
 
 export {
     PLAYERS,
@@ -349,7 +360,7 @@ export {
     convertKeysToSnakeCase,
     determineBackgroundColor,
     determineColor, 
-    determineIsMobile,
+    useIsMobile,
     capitalizeFirstLetter,
     findThreateningBishop
 };

--- a/frontend/src/utility.js
+++ b/frontend/src/utility.js
@@ -1,4 +1,5 @@
 const PLAYERS = ["white", "black"]
+const PROMOTION_PIECES = ["Knight", "Bishop", "Rook", "Queen"]
 
 var BASE_API_URL
 if (process.env.REACT_APP_LOCAL === "true") {
@@ -330,8 +331,9 @@ function findThreateningBishop(boardState, side, row, col) {
 
 const determineIsMobile = () => window.matchMedia("(max-width: 1024px)").matches && window.matchMedia("(orientation: portrait)").matches
 
-export { 
-    PLAYERS, 
+export {
+    PLAYERS,
+    PROMOTION_PIECES,
     IMAGE_MAP, 
     DRAGON_POSITION,
     BOARD_HERALD_POSITION,


### PR DESCRIPTION
## Summary
- Implement piece shop rework with pixel-art card UI, gold display in HUD, and shop/board width alignment
- Add pawn exchange modal for promoting pawns that reach the opposite end
- Fix gold economy: flat +1 gold per capture, shop prices at 2x piece value, remove frontend double-deduction
- Fix broken black piece images, point advantage decimal display, and empty array truthiness checks
- Add reactive `useIsMobile` hook that responds to orientation changes without refresh
- Ignore piece clicks while shop is active to prevent unintended backend state updates
- Add unit tests for gold spent and capture gold, update integration tests for corrected values

## Test plan

### Shop Visual Rework
- [x] Start a game, ensure the king is on home square (row 7, col 4)
- [x] Open the shop — verify the pixel art panel styling (brown frame, banner title, shelf divider)
- [x] Check that gold count shows in both the HUD bar and the shop
- [x] Verify piece cards have parchment backgrounds, centered sprites, and coin+number price tags
- [x] Try with insufficient gold — cards should greyscale with a red "X" overlay, cursor shows "not-allowed"
- [x] Select a piece — card should get a gold border glow
- [x] Click the same piece again — should deselect (toggle behavior)
- [x] Click "Cancel" button in shop footer — should deselect

### HUD Bar
- [x] Verify the HUD renders as a horizontal dark brown bar with Turn counter (left), gold (center), shop button (right)
- [x] Move the king off home square — shop button should disappear, gold display should remain

### Placement UX
- [x] Select a piece from the shop — valid squares on your half (rows 4-7) should show a green overlay highlight instead of the old green buttons
- [x] Hover over a highlighted square — a ghost/transparent preview of the piece should appear
- [x] Click a highlighted square — piece should be placed, gold deducted, overlay disappears
- [x] Verify boss danger zones, sword-in-the-stone, and occupied squares are NOT highlighted

### Pawn Exchange Modal
- [x] This is the hardest to reach naturally — you need to get a white pawn to row 0. You could temporarily hack the board state to place a pawn there, or play through
- [x] When a pawn reaches row 0, the modal should appear with a semi-transparent backdrop over the board
- [x] Verify 4 options show: Knight, Bishop, Rook, Queen (no King)
- [x] Click an option — pawn should be replaced with that piece, modal closes, turn advances

### Mobile
- [x] Resize browser to narrow portrait (or use devtools mobile view) — all elements should scale up proportionally

### Tests
- [x] All 120 unit tests pass
- [x] All 86 integration tests pass