### PR TITLE
Add restart game button to HUD

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Spawns on the a5 square every 15 turns after the 20th turn. Grants a 4-turn buff
 * checkmate protection status effect ✅
 * shop (with light/normal green square for shop square) ✅
 * Add a "Surrender Piece" button to choose which piece to give up after being marked for death amid five dragon buff stacks for the enemy (remember to add piece to captured pieces array) ✅
-* Allow user to restart game from HUD (small button in corner)
+* Allow user to restart game from HUD (small button in corner) ✅
 * rename game to League of Chess
 * for consistency add recursion to convertKeysToSnakeCase() and convertKeysToCamelCase()
 * provide UI to indicate neutral monster buffs (color tint or small monster icons next to pieces + number for stacked buffs) + (board herld buff spreading to pawn must be handled on frontend)
@@ -192,6 +192,7 @@ Spawns on the a5 square every 15 turns after the 20th turn. Grants a 4-turn buff
 * pawn exchange ✅
 * visual cue for a player being able to go again
 * visual cue for turn being skipped (this might be optional since pieces themselves are stunned and user should be able to parse that all their pieces are stunned and king can't move while CPU goes)
+* Delete old game on restart once data lake for historical records is implemented
 * redo assets for rules
 * settle all TODOs
 

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -20,6 +20,19 @@ const HUD = (props) => {
     const isWhiteTurn = turnCount % 2 === 0
     const isKingOnHomeSquare = gameState.boardState[7][4]?.[0]?.type === "white_king"
 
+    const handleConfirmRestart = () => {
+        setShowRestartConfirm(false)
+        setToggleShop(false)
+        props.setShopPieceSelected(null)
+        gameState.restartGame()
+    }
+
+    const confirmBtnStyle = {
+        fontSize: `${isMobile ? 1.4 : 0.7}vw`,
+        padding: `${isMobile ? 0.4 : 0.2}vw ${isMobile ? 1 : 0.5}vw`,
+        borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+    }
+
     useEffect(() => {
         if (!isWhiteTurn || !isKingOnHomeSquare) {
             setToggleShop(false)
@@ -84,37 +97,19 @@ const HUD = (props) => {
                             <span style={{ fontSize: `${isMobile ? 1.4 : 0.7}vw`, opacity: 0.8 }}>Restart?</span>
                             <button
                                 className="pixel-btn"
-                                onClick={() => {
-                                    setShowRestartConfirm(false)
-                                    setToggleShop(false)
-                                    props.setShopPieceSelected(null)
-                                    gameState.restartGame()
-                                }}
-                                style={{
-                                    fontSize: `${isMobile ? 1.4 : 0.7}vw`,
-                                    padding: `${isMobile ? 0.4 : 0.2}vw ${isMobile ? 1 : 0.5}vw`,
-                                    borderRadius: `${isMobile ? 0.6 : 0.3}vw`
-                                }}
+                                onClick={handleConfirmRestart}
+                                style={confirmBtnStyle}
                             >Yes</button>
                             <button
                                 className="pixel-btn"
                                 onClick={() => setShowRestartConfirm(false)}
-                                style={{
-                                    fontSize: `${isMobile ? 1.4 : 0.7}vw`,
-                                    padding: `${isMobile ? 0.4 : 0.2}vw ${isMobile ? 1 : 0.5}vw`,
-                                    borderRadius: `${isMobile ? 0.6 : 0.3}vw`
-                                }}
+                                style={confirmBtnStyle}
                             >No</button>
                         </div> :
                         <button
                             className="pixel-btn"
                             onClick={() => setShowRestartConfirm(true)}
-                            style={{
-                                fontSize: `${isMobile ? 1.4 : 0.7}vw`,
-                                padding: `${isMobile ? 0.4 : 0.2}vw ${isMobile ? 1 : 0.5}vw`,
-                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`,
-                                opacity: 0.7
-                            }}
+                            style={{...confirmBtnStyle, opacity: 0.7}}
                         >Restart</button>
                     }
                 </div>

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -44,18 +44,36 @@ const HUD = (props) => {
                     marginBottom: `${isMobile ? 1 : 0.5}vw`
                 }}>
                     <span style={{ fontSize: `${isMobile ? 2.5 : 1.25}vw` }}>Turn: {turnCount}</span>
-                    {isWhiteTurn && isKingOnHomeSquare ?
+                    <div style={{ display: 'flex', gap: `${isMobile ? 1 : 0.5}vw`, alignItems: 'center' }}>
+                        {isWhiteTurn && isKingOnHomeSquare ?
+                            <button
+                                className="pixel-btn"
+                                onClick={() => handleShopButtonClick()}
+                                style={{
+                                    fontSize: `${isMobile ? 1.8 : 0.9}vw`,
+                                    padding: `${isMobile ? 0.6 : 0.3}vw ${isMobile ? 1.5 : 0.75}vw`,
+                                    borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                                }}
+                            >{toggleShop ? "Close Shop" : "Open Shop"}</button> :
+                            null
+                        }
                         <button
                             className="pixel-btn"
-                            onClick={() => handleShopButtonClick()}
-                            style={{
-                                fontSize: `${isMobile ? 1.8 : 0.9}vw`,
-                                padding: `${isMobile ? 0.6 : 0.3}vw ${isMobile ? 1.5 : 0.75}vw`,
-                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                            onClick={() => {
+                                if (window.confirm("Restart game?")) {
+                                    setToggleShop(false)
+                                    props.setShopPieceSelected(null)
+                                    gameState.restartGame()
+                                }
                             }}
-                        >{toggleShop ? "Close Shop" : "Open Shop"}</button> :
-                        null
-                    }
+                            style={{
+                                fontSize: `${isMobile ? 1.4 : 0.7}vw`,
+                                padding: `${isMobile ? 0.4 : 0.2}vw ${isMobile ? 1 : 0.5}vw`,
+                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`,
+                                opacity: 0.7
+                            }}
+                        >Restart</button>
+                    </div>
                 </div>
                 <div style={{ display: 'flex', gap: `${isMobile ? 3 : 1.5}vw`, alignItems: 'center' }}>
                     <div className="gold-display" style={{ fontSize: `${isMobile ? 2 : 1}vw` }}>

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -11,6 +11,7 @@ const HUD = (props) => {
     const enemyGoldCount = gameState.goldCount?.[PLAYERS[1]] || 0
     const isMobile = useIsMobile()
     const [toggleShop, setToggleShop] = useState(false)
+    const [showRestartConfirm, setShowRestartConfirm] = useState(false)
 
     const handleShopButtonClick = () => {
         setToggleShop(!toggleShop)
@@ -44,28 +45,70 @@ const HUD = (props) => {
                     marginBottom: `${isMobile ? 1 : 0.5}vw`
                 }}>
                     <span style={{ fontSize: `${isMobile ? 2.5 : 1.25}vw` }}>Turn: {turnCount}</span>
-                    <div style={{ display: 'flex', gap: `${isMobile ? 1 : 0.5}vw`, alignItems: 'center' }}>
-                        {isWhiteTurn && isKingOnHomeSquare ?
-                            <button
-                                className="pixel-btn"
-                                onClick={() => handleShopButtonClick()}
-                                style={{
-                                    fontSize: `${isMobile ? 1.8 : 0.9}vw`,
-                                    padding: `${isMobile ? 0.6 : 0.3}vw ${isMobile ? 1.5 : 0.75}vw`,
-                                    borderRadius: `${isMobile ? 0.6 : 0.3}vw`
-                                }}
-                            >{toggleShop ? "Close Shop" : "Open Shop"}</button> :
-                            null
-                        }
+                    {isWhiteTurn && isKingOnHomeSquare ?
                         <button
                             className="pixel-btn"
-                            onClick={() => {
-                                if (window.confirm("Restart game?")) {
+                            onClick={() => handleShopButtonClick()}
+                            style={{
+                                fontSize: `${isMobile ? 1.8 : 0.9}vw`,
+                                padding: `${isMobile ? 0.6 : 0.3}vw ${isMobile ? 1.5 : 0.75}vw`,
+                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                            }}
+                        >{toggleShop ? "Close Shop" : "Open Shop"}</button> :
+                        null
+                    }
+                </div>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <div style={{ display: 'flex', gap: `${isMobile ? 3 : 1.5}vw`, alignItems: 'center' }}>
+                        <div className="gold-display" style={{ fontSize: `${isMobile ? 2 : 1}vw` }}>
+                            <span style={{ color: 'rgb(230, 233, 198)' }}>You:</span>
+                            <img
+                                src={IMAGE_MAP["goldCoin"]}
+                                alt="gold"
+                                style={{ height: `${isMobile ? 2.5 : 1.25}vw` }}
+                            />
+                            <span style={{ color: 'rgb(230, 233, 198)' }}>{goldCount}</span>
+                        </div>
+                        <div className="gold-display" style={{ fontSize: `${isMobile ? 2 : 1}vw`, opacity: 0.7 }}>
+                            <span style={{ color: 'rgb(180, 180, 180)' }}>Enemy:</span>
+                            <img
+                                src={IMAGE_MAP["goldCoin"]}
+                                alt="enemy gold"
+                                style={{ height: `${isMobile ? 2.5 : 1.25}vw`, filter: 'grayscale(100%)' }}
+                            />
+                            <span style={{ color: 'rgb(180, 180, 180)' }}>{enemyGoldCount}</span>
+                        </div>
+                    </div>
+                    {showRestartConfirm ?
+                        <div style={{ display: 'flex', gap: `${isMobile ? 0.6 : 0.3}vw`, alignItems: 'center' }}>
+                            <span style={{ fontSize: `${isMobile ? 1.4 : 0.7}vw`, opacity: 0.8 }}>Restart?</span>
+                            <button
+                                className="pixel-btn"
+                                onClick={() => {
+                                    setShowRestartConfirm(false)
                                     setToggleShop(false)
                                     props.setShopPieceSelected(null)
                                     gameState.restartGame()
-                                }
-                            }}
+                                }}
+                                style={{
+                                    fontSize: `${isMobile ? 1.4 : 0.7}vw`,
+                                    padding: `${isMobile ? 0.4 : 0.2}vw ${isMobile ? 1 : 0.5}vw`,
+                                    borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                                }}
+                            >Yes</button>
+                            <button
+                                className="pixel-btn"
+                                onClick={() => setShowRestartConfirm(false)}
+                                style={{
+                                    fontSize: `${isMobile ? 1.4 : 0.7}vw`,
+                                    padding: `${isMobile ? 0.4 : 0.2}vw ${isMobile ? 1 : 0.5}vw`,
+                                    borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                                }}
+                            >No</button>
+                        </div> :
+                        <button
+                            className="pixel-btn"
+                            onClick={() => setShowRestartConfirm(true)}
                             style={{
                                 fontSize: `${isMobile ? 1.4 : 0.7}vw`,
                                 padding: `${isMobile ? 0.4 : 0.2}vw ${isMobile ? 1 : 0.5}vw`,
@@ -73,27 +116,7 @@ const HUD = (props) => {
                                 opacity: 0.7
                             }}
                         >Restart</button>
-                    </div>
-                </div>
-                <div style={{ display: 'flex', gap: `${isMobile ? 3 : 1.5}vw`, alignItems: 'center' }}>
-                    <div className="gold-display" style={{ fontSize: `${isMobile ? 2 : 1}vw` }}>
-                        <span style={{ color: 'rgb(230, 233, 198)' }}>You:</span>
-                        <img
-                            src={IMAGE_MAP["goldCoin"]}
-                            alt="gold"
-                            style={{ height: `${isMobile ? 2.5 : 1.25}vw` }}
-                        />
-                        <span style={{ color: 'rgb(230, 233, 198)' }}>{goldCount}</span>
-                    </div>
-                    <div className="gold-display" style={{ fontSize: `${isMobile ? 2 : 1}vw`, opacity: 0.7 }}>
-                        <span style={{ color: 'rgb(180, 180, 180)' }}>Enemy:</span>
-                        <img
-                            src={IMAGE_MAP["goldCoin"]}
-                            alt="enemy gold"
-                            style={{ height: `${isMobile ? 2.5 : 1.25}vw`, filter: 'grayscale(100%)' }}
-                        />
-                        <span style={{ color: 'rgb(180, 180, 180)' }}>{enemyGoldCount}</span>
-                    </div>
+                    }
                 </div>
             </div>
             {

--- a/frontend/src/context/GameStateContext.js
+++ b/frontend/src/context/GameStateContext.js
@@ -35,7 +35,8 @@ const GameStateContext = createContext({
     neutralBuffLog: {
         white: {dragon: {stacks:0, turn: 0}, boardHerald: {active: false, turn: 0}, baronNashor: {active: false, turn: 0}},
         black: {dragon: {stacks:0, turn: 0}, boardHerald: {active: false, turn: 0}, baronNashor: {active: false, turn: 0}}
-    }
+    },
+    restartGame: () => {}
 })
 
 export function GameStateContextData() {

--- a/frontend/src/context/GameStateContext.js
+++ b/frontend/src/context/GameStateContext.js
@@ -65,8 +65,9 @@ export function GameStateProvider({children}) {
         })
         .then(jsonResponse => {
             const parsedJsonResponse = {
-                ...convertKeysToCamelCase(jsonResponse), 
-                updateGameState: updateGameState
+                ...convertKeysToCamelCase(jsonResponse),
+                updateGameState: updateGameState,
+                restartGame: restartGame
             }
             setGameState(parsedJsonResponse)
             sessionStorage.setItem("lastUpdated", parsedJsonResponse["lastUpdated"])
@@ -153,8 +154,9 @@ export function GameStateProvider({children}) {
                 console.log(`GET Game ${result["id"]}`)
             }
             const parsedResult = {
-                ...convertKeysToCamelCase(result), 
-                updateGameState: updateGameState
+                ...convertKeysToCamelCase(result),
+                updateGameState: updateGameState,
+                restartGame: restartGame
             }
             setGameState(parsedResult)
             sessionStorage.setItem("gameStateId", parsedResult["id"])
@@ -165,6 +167,14 @@ export function GameStateProvider({children}) {
             console.log(exception);
             fetchInProgress.current = false
         });
+    }
+
+    const restartGame = () => {
+        sessionStorage.removeItem("gameStateId")
+        sessionStorage.removeItem("lastUpdated")
+        setGameState({...initGameState, updateGameState, restartGame})
+        fetchInProgress.current = false
+        fetchGameState()
     }
 
     useEffect(() => {

--- a/frontend/src/context/GameStateContext.js
+++ b/frontend/src/context/GameStateContext.js
@@ -128,10 +128,12 @@ export function GameStateProvider({children}) {
     const [gameState, setGameState] = useState(initGameState);
 
     const fetchInProgress = useRef(false)
+    const fetchGeneration = useRef(0)
 
     const fetchGameState = () => {
         if (fetchInProgress.current) return
         fetchInProgress.current = true
+        const currentGeneration = fetchGeneration.current
 
         var url
         var method
@@ -148,6 +150,10 @@ export function GameStateProvider({children}) {
         fetch(url, {"method": method})
         .then(response => response.json())
         .then(result => {
+            if (fetchGeneration.current !== currentGeneration) {
+                fetchInProgress.current = false
+                return
+            }
             if (method === "POST") {
                 console.log(`POST Game ID - ${result["id"]}`)
             } else {
@@ -170,6 +176,7 @@ export function GameStateProvider({children}) {
     }
 
     const restartGame = () => {
+        fetchGeneration.current += 1
         sessionStorage.removeItem("gameStateId")
         sessionStorage.removeItem("lastUpdated")
         setGameState({...initGameState, updateGameState, restartGame})


### PR DESCRIPTION
## Summary
- Adds a "Restart" button to the bottom-right corner of the HUD that starts a fresh game without closing the tab
- Uses inline "Restart? Yes / No" confirmation instead of a browser dialog
- Clears sessionStorage and lets `fetchGameState` POST a new game; old game is preserved in DB for future historical reference
- Closes shop and clears shop piece selection on restart

## Test plan
- [x] Click "Restart" → inline confirmation appears
- [x] Click "No" → nothing happens, confirmation dismisses
- [x] Click "Yes" → board resets, turn count goes to 0, captured pieces clear, shop closes, new game ID in sessionStorage
- [x] Verify old game still exists in DB (not deleted)
- [x] Play new game normally after restart
- [x] Verify button renders correctly on both desktop and mobile viewports