### PR TITLE
Add turn count flash indicators for go-again and turn-skip events

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ Spawns on the a5 square every 15 turns after the 20th turn. Grants a 4-turn buff
 * add UI for draw
 * shop rework ✅
 * pawn exchange ✅
-* visual cue for a player being able to go again
-* visual cue for turn being skipped (this might be optional since pieces themselves are stunned and user should be able to parse that all their pieces are stunned and king can't move while CPU goes)
+* visual cue for a player being able to go again ✅
+* visual cue for turn being skipped (this might be optional since pieces themselves are stunned and user should be able to parse that all their pieces are stunned and king can't move while CPU goes) ✅
 * Delete old game on restart once data lake for historical records is implemented
 * redo assets for rules
 * settle all TODOs

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Spawns on the a5 square every 15 turns after the 20th turn. Grants a 4-turn buff
 * Delete old game on restart once data lake for historical records is implemented
 * redo assets for rules
 * settle all TODOs
+* handle warnings
 
 ##### Backend 
 * MongoDB database  ✅

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -7,6 +7,8 @@ import Shop from './Shop';
 const HUD = (props) => {
     const gameState = GameStateContextData()
     const turnCount = gameState.turnCount
+    const queenReset = gameState.queenReset
+    const bishopSpecialCaptures = gameState.bishopSpecialCaptures
     const goldCount = gameState.goldCount?.[PLAYERS[0]] || 0
     const enemyGoldCount = gameState.goldCount?.[PLAYERS[1]] || 0
     const isMobile = useIsMobile()
@@ -14,7 +16,16 @@ const HUD = (props) => {
     const [showRestartConfirm, setShowRestartConfirm] = useState(false)
     const [turnFlashClass, setTurnFlashClass] = useState('')
     const prevTurnCount = useRef(turnCount)
+    const prevQueenReset = useRef(queenReset)
+    const prevBishopCaptures = useRef(bishopSpecialCaptures?.length ?? 0)
     const isInitialLoad = useRef(true)
+
+    const triggerFlash = (isPlayerTurn) => {
+        const flashClass = isPlayerTurn ? 'turn-flash-green' : 'turn-flash-red'
+        setTurnFlashClass(flashClass)
+        const timer = setTimeout(() => setTurnFlashClass(''), 1000)
+        return () => clearTimeout(timer)
+    }
 
     useEffect(() => {
         const prev = prevTurnCount.current
@@ -31,12 +42,30 @@ const HUD = (props) => {
         const currIsPlayerTurn = turnCount % 2 === 0
 
         if (prevIsPlayerTurn === currIsPlayerTurn) {
-            const flashClass = currIsPlayerTurn ? 'turn-flash-green' : 'turn-flash-red'
-            setTurnFlashClass(flashClass)
-            const timer = setTimeout(() => setTurnFlashClass(''), 1000)
-            return () => clearTimeout(timer)
+            return triggerFlash(currIsPlayerTurn)
         }
     }, [turnCount])
+
+    useEffect(() => {
+        const prev = prevQueenReset.current
+        prevQueenReset.current = queenReset
+
+        if (!prev && queenReset) {
+            const isPlayerTurn = turnCount % 2 === 0
+            return triggerFlash(isPlayerTurn)
+        }
+    }, [queenReset, turnCount])
+
+    useEffect(() => {
+        const prevLen = prevBishopCaptures.current
+        const currLen = bishopSpecialCaptures?.length ?? 0
+        prevBishopCaptures.current = currLen
+
+        if (currLen > prevLen) {
+            const isPlayerTurn = turnCount % 2 === 0
+            return triggerFlash(isPlayerTurn)
+        }
+    }, [bishopSpecialCaptures, turnCount])
 
     const handleShopButtonClick = () => {
         setToggleShop(!toggleShop)

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
 import { IMAGE_MAP, PLAYERS, useIsMobile } from '../utility';
 import Shop from './Shop';
@@ -12,6 +12,25 @@ const HUD = (props) => {
     const isMobile = useIsMobile()
     const [toggleShop, setToggleShop] = useState(false)
     const [showRestartConfirm, setShowRestartConfirm] = useState(false)
+    const [turnFlashClass, setTurnFlashClass] = useState('')
+    const prevTurnCount = useRef(turnCount)
+
+    useEffect(() => {
+        const prev = prevTurnCount.current
+        prevTurnCount.current = turnCount
+
+        if (prev === turnCount) return
+
+        const prevIsPlayerTurn = prev % 2 === 0
+        const currIsPlayerTurn = turnCount % 2 === 0
+
+        if (prevIsPlayerTurn === currIsPlayerTurn) {
+            const flashClass = currIsPlayerTurn ? 'turn-flash-green' : 'turn-flash-red'
+            setTurnFlashClass(flashClass)
+            const timer = setTimeout(() => setTurnFlashClass(''), 1000)
+            return () => clearTimeout(timer)
+        }
+    }, [turnCount])
 
     const handleShopButtonClick = () => {
         setToggleShop(!toggleShop)
@@ -57,7 +76,7 @@ const HUD = (props) => {
                     justifyContent: 'space-between',
                     marginBottom: `${isMobile ? 1 : 0.5}vw`
                 }}>
-                    <span style={{ fontSize: `${isMobile ? 2.5 : 1.25}vw` }}>Turn: {turnCount}</span>
+                    <span className={turnFlashClass} style={{ fontSize: `${isMobile ? 2.5 : 1.25}vw`, display: 'inline-block' }}>Turn: {turnCount}</span>
                     {isWhiteTurn && isKingOnHomeSquare ?
                         <button
                             className="pixel-btn"

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -14,10 +14,16 @@ const HUD = (props) => {
     const [showRestartConfirm, setShowRestartConfirm] = useState(false)
     const [turnFlashClass, setTurnFlashClass] = useState('')
     const prevTurnCount = useRef(turnCount)
+    const isInitialLoad = useRef(true)
 
     useEffect(() => {
         const prev = prevTurnCount.current
         prevTurnCount.current = turnCount
+
+        if (isInitialLoad.current) {
+            isInitialLoad.current = false
+            return
+        }
 
         if (prev === turnCount) return
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -208,6 +208,26 @@ progress {
     font-size: 0.25vw;
 }
 
+@keyframes turn-flash-green {
+    0% { color: white; transform: scale(1); }
+    20% { color: rgb(80, 220, 80); transform: scale(1.4); }
+    100% { color: white; transform: scale(1); }
+}
+
+@keyframes turn-flash-red {
+    0% { color: white; transform: scale(1); }
+    20% { color: rgb(230, 60, 60); transform: scale(1.4); }
+    100% { color: white; transform: scale(1); }
+}
+
+.turn-flash-green {
+    animation: turn-flash-green 1s ease-out;
+}
+
+.turn-flash-red {
+    animation: turn-flash-red 1s ease-out;
+}
+
 /* For Mobile */
 @media screen and (max-width: 1024px) 
               and (orientation: portrait) {


### PR DESCRIPTION
## Summary
- Add visual turn flash indicators to the HUD's turn counter for non-standard turn progression events
- Green flash when something benefits the player (go-again or enemy skip), red flash when it benefits the enemy
- Three detection paths:
  - **Queen reset**: queen kill/assist gives the same player another turn (turnCount stays the same, `queenReset` flips to true)
  - **Bishop 3-stack debuff**: opponent must resolve a capture/spare (`bishopSpecialCaptures` goes from empty to non-empty)
  - **Stun-induced skip**: all non-king pieces stunned and king can't move (turnCount increments by 2, parity unchanged)
- CSS keyframe animations (`turn-flash-green`, `turn-flash-red`) on the turn counter text with a 1s duration

## Test plan
- [ ] Trigger a queen kill reset and verify green flash on the turn counter
- [ ] Trigger a queen assist reset and verify green flash on the turn counter
- [ ] Get a bishop to 3-stack an enemy piece and verify green flash when capture prompt appears
- [ ] Stun all enemy non-king pieces with queen while king is blocked and verify green flash on skip
- [ ] Verify no flash occurs on normal turn advancement
- [ ] Verify no flash on piece selection/deselection (positionInPlay changes only)
- [ ] Verify no flash on pawn exchange or marked-for-death resolution
- [ ] Test on mobile viewport to confirm flash renders correctly


https://claude.ai/code/session_018NBExi7LUfstXNRk7C9icz