### PR TITLE
Add neutral monster buff indicators to pieces

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Spawns on the a5 square every 15 turns after the 20th turn. Grants a 4-turn buff
 * Allow user to restart game from HUD (small button in corner) ✅
 * rename game to League of Chess ✅
 * for consistency add recursion to convertKeysToSnakeCase() and convertKeysToCamelCase() ✅
-* provide UI to indicate neutral monster buffs (color tint or small monster icons next to pieces + number for stacked buffs) + (board herld buff spreading to pawn must be handled on frontend)
+* provide UI to indicate neutral monster buffs (color tint or small monster icons next to pieces + number for stacked buffs) + (board herld buff spreading to pawn must be handled on frontend) ✅
 * change favicon and website/tab title ✅
 * add castle button ✅
 * make victory and defeat UI transparent ✅

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -88,6 +88,7 @@ const Board = () => {
                                                         health={piece.health}
                                                         shopPieceSelected={shopPieceSelected}
                                                         markedForDeath={piece.markedForDeath}
+                                                        neutralBuffLog={gameState.neutralBuffLog}
                                                         // Only white king gets castle buttons; black castling is handled by AI
                                                         castleMoves={piece.type === "white_king" ? castleMoves : []}
                                                     />

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -88,6 +88,7 @@ const Board = () => {
                                                         health={piece.health}
                                                         shopPieceSelected={shopPieceSelected}
                                                         markedForDeath={piece.markedForDeath}
+                                                        boardHeraldBuff={piece.boardHeraldBuff}
                                                         neutralBuffLog={gameState.neutralBuffLog}
                                                         // Only white king gets castle buttons; black castling is handled by AI
                                                         castleMoves={piece.type === "white_king" ? castleMoves : []}

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -475,45 +475,53 @@ const Piece = (props) => {
                 }): null
             }
             {activeNeutralBuffs.length > 0 ?
-                activeNeutralBuffs.map((buff, i) => (
-                    <div
-                        key={`buff-${buff.key}`}
-                        className="neutral-buff-indicator"
-                        style={{
-                            position: 'absolute',
-                            top: `${topPosition + (i * (isMobile ? 1.6 : 0.8))}vw`,
-                            left: `${leftPosition - (isMobile ? 1.8 : 0.9)}vw`,
-                            width: isMobile ? '1.6vw' : '0.8vw',
-                            height: isMobile ? '1.6vw' : '0.8vw',
-                            zIndex: 5,
-                            pointerEvents: 'none'
-                        }}
-                    >
-                        <img
-                            src={IMAGE_MAP[buff.icon]}
-                            alt={buff.key}
+                (() => {
+                    const buffIconSize = isMobile ? 1.6 : 0.8
+                    const buffIconLeftOffset = isMobile ? 1.8 : 0.9
+                    const buffCountBottomOffset = isMobile ? -0.6 : -0.3
+                    const buffCountRightOffset = isMobile ? -0.6 : -0.3
+                    const buffCountFontSize = isMobile ? '1vw' : '0.5vw'
+
+                    return activeNeutralBuffs.map((buff, i) => (
+                        <div
+                            key={`buff-${buff.key}`}
+                            className="neutral-buff-indicator"
                             style={{
-                                width: '100%',
-                                height: '100%',
-                                imageRendering: 'pixelated'
+                                position: 'absolute',
+                                top: `${topPosition + (i * buffIconSize)}vw`,
+                                left: `${leftPosition - buffIconLeftOffset}vw`,
+                                width: `${buffIconSize}vw`,
+                                height: `${buffIconSize}vw`,
+                                zIndex: 5,
+                                pointerEvents: 'none'
                             }}
-                        />
-                        {buff.count !== null ?
-                            <span
+                        >
+                            <img
+                                src={IMAGE_MAP[buff.icon]}
+                                alt={buff.key}
                                 style={{
-                                    position: 'absolute',
-                                    bottom: isMobile ? '-0.6vw' : '-0.3vw',
-                                    right: isMobile ? '-0.6vw' : '-0.3vw',
-                                    fontSize: isMobile ? '1vw' : '0.5vw',
-                                    fontWeight: 'bold',
-                                    color: 'white',
-                                    textShadow: '1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black, -1px 1px 1px black',
-                                    lineHeight: 1
+                                    width: '100%',
+                                    height: '100%',
+                                    imageRendering: 'pixelated'
                                 }}
-                            >{buff.count}</span>
-                        : null}
-                    </div>
-                )) : null
+                            />
+                            {buff.count !== null ?
+                                <span
+                                    style={{
+                                        position: 'absolute',
+                                        bottom: `${buffCountBottomOffset}vw`,
+                                        right: `${buffCountRightOffset}vw`,
+                                        fontSize: buffCountFontSize,
+                                        fontWeight: 'bold',
+                                        color: 'white',
+                                        textShadow: '1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black, -1px 1px 1px black',
+                                        lineHeight: 1
+                                    }}
+                                >{buff.count}</span>
+                            : null}
+                        </div>
+                    ))
+                })() : null
             }
         </div>
     );

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -270,6 +270,24 @@ const Piece = (props) => {
         backgroundColor: bgColor,
     })
 
+    const isAdjacentToHeraldBuffedPiece = () => {
+        if (!props.type.toLowerCase().includes('pawn')) return false
+        const boardState = gameState.boardState
+        for (let dr = -1; dr <= 1; dr++) {
+            for (let dc = -1; dc <= 1; dc++) {
+                if (dr === 0 && dc === 0) continue
+                const r = props.row + dr
+                const c = props.col + dc
+                if (r < 0 || r > 7 || c < 0 || c > 7) continue
+                const square = boardState[r]?.[c]
+                if (square?.some(piece => piece.type.includes(props.side) && piece.boardHeraldBuff)) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
     const getActiveNeutralBuffs = () => {
         if (!props.neutralBuffLog || props.side === 'neutral') return []
         const playerBuffs = props.neutralBuffLog[props.side]
@@ -283,8 +301,8 @@ const Piece = (props) => {
             buffs.push({ key: 'dragon', icon: 'neutralDragon', count: playerBuffs.dragon.stacks })
         }
 
-        // Board Herald: show on all pieces when active
-        if (playerBuffs.boardHerald?.active) {
+        // Board Herald: show on the piece that captured it, and on adjacent allied pawns
+        if (props.boardHeraldBuff || (playerBuffs.boardHerald?.active && isAdjacentToHeraldBuffedPiece())) {
             buffs.push({ key: 'herald', icon: 'neutralBoardHerald', count: null })
         }
 

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -270,6 +270,34 @@ const Piece = (props) => {
         backgroundColor: bgColor,
     })
 
+    const getActiveNeutralBuffs = () => {
+        if (!props.neutralBuffLog || props.side === 'neutral') return []
+        const playerBuffs = props.neutralBuffLog[props.side]
+        if (!playerBuffs) return []
+
+        const buffs = []
+        const isPawn = props.type.toLowerCase().includes('pawn')
+
+        // Dragon: team-wide buff, show on all pieces
+        if (playerBuffs.dragon?.stacks > 0) {
+            buffs.push({ key: 'dragon', icon: 'neutralDragon', count: playerBuffs.dragon.stacks })
+        }
+
+        // Board Herald: show on all pieces when active
+        if (playerBuffs.boardHerald?.active) {
+            buffs.push({ key: 'herald', icon: 'neutralBoardHerald', count: null })
+        }
+
+        // Baron Nashor: pawn buff, show on pawns only
+        if (playerBuffs.baronNashor?.active && isPawn) {
+            buffs.push({ key: 'baron', icon: 'neutralBaronNashor', count: null })
+        }
+
+        return buffs
+    }
+
+    const activeNeutralBuffs = getActiveNeutralBuffs()
+
     const buffedSrc = props.pawnBuff ? props.type + `${props.pawnBuff + 1}` : props.type
     const image_src = IMAGE_MAP[buffedSrc] ? buffedSrc : props.type
     const className = pickClassName()
@@ -416,7 +444,7 @@ const Piece = (props) => {
             {props.checkProtection ?
                 Array.from({length: props.checkProtection}, (_, i) => i + 1).map((count) => {
                     return(
-                    <img 
+                    <img
                         src={IMAGE_MAP['checkProtection']}
                         className={pickClassName()}
                         style={{
@@ -427,6 +455,47 @@ const Piece = (props) => {
                         }}
                     />);
                 }): null
+            }
+            {activeNeutralBuffs.length > 0 ?
+                activeNeutralBuffs.map((buff, i) => (
+                    <div
+                        key={`buff-${buff.key}`}
+                        className="neutral-buff-indicator"
+                        style={{
+                            position: 'absolute',
+                            top: `${topPosition + (i * (isMobile ? 1.6 : 0.8))}vw`,
+                            left: `${leftPosition - (isMobile ? 1.8 : 0.9)}vw`,
+                            width: isMobile ? '1.6vw' : '0.8vw',
+                            height: isMobile ? '1.6vw' : '0.8vw',
+                            zIndex: 5,
+                            pointerEvents: 'none'
+                        }}
+                    >
+                        <img
+                            src={IMAGE_MAP[buff.icon]}
+                            alt={buff.key}
+                            style={{
+                                width: '100%',
+                                height: '100%',
+                                imageRendering: 'pixelated'
+                            }}
+                        />
+                        {buff.count !== null ?
+                            <span
+                                style={{
+                                    position: 'absolute',
+                                    bottom: isMobile ? '-0.6vw' : '-0.3vw',
+                                    right: isMobile ? '-0.6vw' : '-0.3vw',
+                                    fontSize: isMobile ? '1vw' : '0.5vw',
+                                    fontWeight: 'bold',
+                                    color: 'white',
+                                    textShadow: '1px 1px 1px black, -1px -1px 1px black, 1px -1px 1px black, -1px 1px 1px black',
+                                    lineHeight: 1
+                                }}
+                            >{buff.count}</span>
+                        : null}
+                    </div>
+                )) : null
             }
         </div>
     );

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -367,13 +367,14 @@ const Piece = (props) => {
                 <p 
                     className={pickClassName()}
                     style={{
-                        top: `${topPosition + (2.55 * (isMobile ? 2: 1))}vw`,
+                        top: `${topPosition + (1.5 * (isMobile ? 2: 1))}vw`,
                         left: `${leftPosition - (0.75 * (isMobile ? 2: 1))}vw`,
                         fontWeight: 'bold',
-                        background: '-webkit-linear-gradient(white, blue)',
+                        background: '-webkit-linear-gradient(#00e5ff, #b347ea)',
                         WebkitBackgroundClip: 'text',
                         WebkitTextFillColor: 'transparent',
-                        fontSize: isMobile ? '2.4vw': '1.2vw'
+                        filter: 'drop-shadow(0 0 1px rgba(0,0,0,0.8))',
+                        fontSize: isMobile ? '2.4vw': '0.8vw'
                     }}
                 >
                     {props.energizeStacks}
@@ -386,10 +387,10 @@ const Piece = (props) => {
                         src={IMAGE_MAP['bishopDebuff']}
                         className={pickClassName()}
                         style={{
-                            width: isMobile ? '1.4vw': '0.7vw',
-                            height: isMobile ? '1.4vw': '0.7vw',
+                            width: isMobile ? '2.2vw': '0.7vw',
+                            height: isMobile ? '2.2vw': '0.7vw',
                             top: `${topPosition + (isMobile ? 5.5 : 2.75)}vw`,
-                            left: `${leftPosition - (isMobile ? 3 : 1.5) + (count * (isMobile ? 2 : 1))}vw`
+                            left: `${leftPosition - (isMobile ? 4 : 1.5) + (count * (isMobile ? 2.8 : 1))}vw`
                         }}
                     />);
                 }): null
@@ -466,21 +467,19 @@ const Piece = (props) => {
                         src={IMAGE_MAP['checkProtection']}
                         className={pickClassName()}
                         style={{
-                            width: isMobile ? '2.3vw': '1.15vw',
-                            height: isMobile ? '2.3vw': '1.15vw',
+                            width: isMobile ? '2.8vw': '0.9vw',
+                            height: isMobile ? '2.8vw': '0.9vw',
                             top: `${topPosition}vw`,
-                            left: `${leftPosition - (isMobile ? 3.5: 1.75) + (count * (isMobile ? 3.6: 1.2))}vw`
+                            left: `${leftPosition - (isMobile ? 4 : 1.5) + (count * (isMobile ? 3 : 1))}vw`
                         }}
                     />);
                 }): null
             }
             {activeNeutralBuffs.length > 0 ?
                 (() => {
-                    const buffIconSize = isMobile ? 1.6 : 0.8
-                    const buffIconLeftOffset = isMobile ? 1.8 : 0.9
-                    const buffCountBottomOffset = isMobile ? -0.6 : -0.3
-                    const buffCountRightOffset = isMobile ? -0.6 : -0.3
-                    const buffCountFontSize = isMobile ? '1vw' : '0.5vw'
+                    const buffIconSize = isMobile ? 3.6 : 1.2
+                    const squareSize = 3.7 * (isMobile ? 2 : 1)
+                    const buffCountFontSize = isMobile ? '1.6vw' : '0.5vw'
 
                     return activeNeutralBuffs.map((buff, i) => (
                         <div
@@ -489,7 +488,7 @@ const Piece = (props) => {
                             style={{
                                 position: 'absolute',
                                 top: `${topPosition + (i * buffIconSize)}vw`,
-                                left: `${leftPosition - buffIconLeftOffset}vw`,
+                                left: `${leftPosition + squareSize - buffIconSize}vw`,
                                 width: `${buffIconSize}vw`,
                                 height: `${buffIconSize}vw`,
                                 zIndex: 5,
@@ -509,8 +508,8 @@ const Piece = (props) => {
                                 <span
                                     style={{
                                         position: 'absolute',
-                                        bottom: `${buffCountBottomOffset}vw`,
-                                        right: `${buffCountRightOffset}vw`,
+                                        bottom: 0,
+                                        right: 0,
                                         fontSize: buffCountFontSize,
                                         fontWeight: 'bold',
                                         color: 'white',

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -477,8 +477,9 @@ const Piece = (props) => {
             }
             {activeNeutralBuffs.length > 0 ?
                 (() => {
-                    const buffIconSize = isMobile ? 3.6 : 1.2
                     const squareSize = 3.7 * (isMobile ? 2 : 1)
+                    const baseBuffIconSize = isMobile ? 3.6 : 1.2
+                    const buffIconSize = Math.min(baseBuffIconSize, (squareSize * 0.85) / activeNeutralBuffs.length)
                     const buffCountFontSize = isMobile ? '1.6vw' : '0.5vw'
 
                     return activeNeutralBuffs.map((buff, i) => (


### PR DESCRIPTION
## Summary
- Adds neutral monster buff indicators to pieces, rendered as small monster icons stacked vertically on the right side of each piece
- Dragon buff: shown on all allied pieces with a stack count badge (1-5)
- Board Herald buff: shown on the specific piece that captured it (using the existing `boardHeraldBuff` piece-level flag from the backend) and on adjacent allied pawns
- Baron Nashor buff: shown on all allied pawns while active
- Pieces with multiple active buffs display all applicable icons stacked vertically, auto-shrinking to fit within the square

## Changes
- `Board.js`: passes `neutralBuffLog` and `boardHeraldBuff` props to `Piece` components
- `Piece.js`: adds `getActiveNeutralBuffs()` to determine which buffs apply per piece, `isAdjacentToHeraldBuffedPiece()` for Herald pawn spreading, and renders buff icons with pixelated monster images + count badges
- UI polish: repositioned buff icons to top-right of squares, resized check protection and energize stacks indicators, fixed overlaps between energize stacks and bishop debuff, increased mobile indicator sizes, added dynamic icon shrinking for multi-buff scenarios

## Test plan
- [x] Capture a dragon and verify the dragon icon with stack count appears on all allied pieces
- [x] Capture multiple dragons and verify the stack count increments
- [x] Capture the Board Herald and verify the icon appears only on the capturing piece
- [x] Move a pawn adjacent to the Herald-buffed piece and verify it also shows the icon
- [x] Capture Baron Nashor and verify the icon appears on all allied pawns (not other pieces)
- [x] Trigger multiple buffs simultaneously and verify icons stack vertically without overlapping
- [x] Verify buff icons disappear when buffs expire
- [x] Test on mobile viewport to verify responsive sizing

<https://claude.ai/code/session_011CvdpQSEvWiyuEdc8CkppR>