### PR TITLE
Add wooden board frame and fix captured pieces layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,6 @@ Spawns on the a5 square every 15 turns after the 20th turn. Grants a 4-turn buff
 * visual cue for turn being skipped (this might be optional since pieces themselves are stunned and user should be able to parse that all their pieces are stunned and king can't move while CPU goes) ✅
 * Delete old game on restart once data lake for historical records is implemented
 * redo assets for rules
-* settle all TODOs
 * handle warnings
 
 ##### Backend 

--- a/frontend/src/components/Background.js
+++ b/frontend/src/components/Background.js
@@ -111,18 +111,6 @@ const Square = (props) => {
             className="square"
             onClick={() => handleSquareClick()}
         >
-            <p
-                style={{ color, fontSize: "1vw", opacity: col === 0 ? 1 : 0 }}
-                className='label' >{8-row}</p>
-            <p
-                style={{
-                    color,
-                    alignSelf: "flex-end",
-                    fontSize: "1vw",
-                    opacity: row === 7 ? 1 : 0
-                }}
-                className='label'
-            >{String.fromCharCode(97 + col)}</p>
             {showHighlight && (
                 <div
                     className="valid-square-highlight"

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -53,12 +53,80 @@ const Board = () => {
         setPawnExchangePosition(null)
     }, [boardState, possibleMoves, possibleCaptures, turnCount])
 
+    const gutterSize = isMobile ? 2.4 : 1.2
+    const borderSize = isMobile ? 0.5 : 0.25
+    const bevelSize = isMobile ? 0.3 : 0.15
+    const boardSize = isMobile ? 59.2 : 29.6
+    const labelFontSize = isMobile ? '1.6vw' : '0.8vw'
+
     return(
         <div style={isMobile ? {display: "block", margin: "auto"}: null}>
-            <CapturedPieces 
-                side={PLAYERS[1]}
-            />
-            <div style={{position: 'relative'}}>
+            <div style={{ marginBottom: `${isMobile ? 1 : 0.5}vw` }}>
+                <CapturedPieces
+                    side={PLAYERS[1]}
+                />
+            </div>
+            <div style={{
+                display: 'inline-block',
+                backgroundColor: 'rgb(71, 33, 1)',
+                border: `${borderSize}vw solid rgb(50, 23, 0)`,
+                padding: `${gutterSize * 0.5}vw ${gutterSize}vw ${gutterSize}vw ${gutterSize}vw`,
+                boxSizing: 'content-box',
+                position: 'relative',
+                imageRendering: 'pixelated',
+                boxShadow: `inset ${bevelSize}vw ${bevelSize}vw 0 rgb(125, 59, 2), inset -${bevelSize}vw -${bevelSize}vw 0 rgb(40, 18, 0)`,
+            }}>
+                {/* Row labels (8-1) in the left gutter */}
+                <div style={{
+                    position: 'absolute',
+                    left: 0,
+                    top: `${gutterSize * 0.5}vw`,
+                    width: `${gutterSize}vw`,
+                    height: `${boardSize}vw`,
+                    display: 'flex',
+                    flexDirection: 'column',
+                }}>
+                    {[8,7,6,5,4,3,2,1].map(num => (
+                        <div key={num} style={{
+                            flex: 1,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            color: 'rgb(230, 233, 198)',
+                            fontSize: labelFontSize,
+                            fontFamily: 'Basic',
+                            fontWeight: 'bold',
+                        }}>{num}</div>
+                    ))}
+                </div>
+                {/* Column labels (a-h) in the bottom gutter */}
+                <div style={{
+                    position: 'absolute',
+                    bottom: 0,
+                    left: `${gutterSize}vw`,
+                    width: `${boardSize}vw`,
+                    height: `${gutterSize}vw`,
+                    display: 'flex',
+                    flexDirection: 'row',
+                }}>
+                    {['a','b','c','d','e','f','g','h'].map(letter => (
+                        <div key={letter} style={{
+                            flex: 1,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            color: 'rgb(230, 233, 198)',
+                            fontSize: labelFontSize,
+                            fontFamily: 'Basic',
+                            fontWeight: 'bold',
+                        }}>{letter}</div>
+                    ))}
+                </div>
+                {/* The board */}
+                <div style={{
+                    position: 'relative',
+                    outline: `${isMobile ? 0.2 : 0.1}vw solid rgb(40, 18, 0)`,
+                }}>
                 <Background 
                     possibleCaptures={possibleCaptures}
                     shopPieceSelected={shopPieceSelected}
@@ -134,6 +202,7 @@ const Board = () => {
                         onExchange={() => setPawnExchangePosition(null)}
                     />
                 )}
+                </div>
             </div>
             <HUD
                 shopPieceSelected={shopPieceSelected}

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -61,7 +61,7 @@ const Board = () => {
 
     return(
         <div style={isMobile ? {display: "block", margin: "auto"}: null}>
-            <div style={{ marginBottom: `${isMobile ? 1 : 0.5}vw` }}>
+            <div style={{ marginBottom: `${isMobile ? 2 : 1}vw` }}>
                 <CapturedPieces
                     side={PLAYERS[1]}
                 />

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -16,6 +16,12 @@ import { GameStateContextData }  from '../context/GameStateContext';
 
 import { PLAYERS, pickSide, snakeToCamel, useIsMobile } from '../utility';
 
+const FRAME_BG_COLOR = 'rgb(71, 33, 1)'
+const FRAME_BORDER_COLOR = 'rgb(50, 23, 0)'
+const FRAME_BEVEL_LIGHT = 'rgb(125, 59, 2)'
+const FRAME_BEVEL_DARK = 'rgb(40, 18, 0)'
+const LABEL_COLOR = 'rgb(230, 233, 198)'
+
 const Board = () => {
     // positionInPlay used to figure out what piece is being moved by player
     const gameState = GameStateContextData()
@@ -56,8 +62,19 @@ const Board = () => {
     const gutterSize = isMobile ? 2.4 : 1.2
     const borderSize = isMobile ? 0.5 : 0.25
     const bevelSize = isMobile ? 0.3 : 0.15
+    // 8 squares × (3vw width + 2 × 0.35vw padding) = 29.6vw; mobile doubles all values
     const boardSize = isMobile ? 59.2 : 29.6
     const labelFontSize = isMobile ? '1.6vw' : '0.8vw'
+    const labelCellStyle = {
+        flex: 1,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: LABEL_COLOR,
+        fontSize: labelFontSize,
+        fontFamily: 'Basic',
+        fontWeight: 'bold',
+    }
 
     return(
         <div style={isMobile ? {display: "block", margin: "auto"}: null}>
@@ -68,13 +85,13 @@ const Board = () => {
             </div>
             <div style={{
                 display: 'inline-block',
-                backgroundColor: 'rgb(71, 33, 1)',
-                border: `${borderSize}vw solid rgb(50, 23, 0)`,
+                backgroundColor: FRAME_BG_COLOR,
+                border: `${borderSize}vw solid ${FRAME_BORDER_COLOR}`,
                 padding: `${gutterSize * 0.5}vw ${gutterSize}vw ${gutterSize}vw ${gutterSize}vw`,
                 boxSizing: 'content-box',
                 position: 'relative',
                 imageRendering: 'pixelated',
-                boxShadow: `inset ${bevelSize}vw ${bevelSize}vw 0 rgb(125, 59, 2), inset -${bevelSize}vw -${bevelSize}vw 0 rgb(40, 18, 0)`,
+                boxShadow: `inset ${bevelSize}vw ${bevelSize}vw 0 ${FRAME_BEVEL_LIGHT}, inset -${bevelSize}vw -${bevelSize}vw 0 ${FRAME_BEVEL_DARK}`,
             }}>
                 {/* Row labels (8-1) in the left gutter */}
                 <div style={{
@@ -87,16 +104,7 @@ const Board = () => {
                     flexDirection: 'column',
                 }}>
                     {[8,7,6,5,4,3,2,1].map(num => (
-                        <div key={num} style={{
-                            flex: 1,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            color: 'rgb(230, 233, 198)',
-                            fontSize: labelFontSize,
-                            fontFamily: 'Basic',
-                            fontWeight: 'bold',
-                        }}>{num}</div>
+                        <div key={num} style={labelCellStyle}>{num}</div>
                     ))}
                 </div>
                 {/* Column labels (a-h) in the bottom gutter */}
@@ -110,22 +118,13 @@ const Board = () => {
                     flexDirection: 'row',
                 }}>
                     {['a','b','c','d','e','f','g','h'].map(letter => (
-                        <div key={letter} style={{
-                            flex: 1,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            color: 'rgb(230, 233, 198)',
-                            fontSize: labelFontSize,
-                            fontFamily: 'Basic',
-                            fontWeight: 'bold',
-                        }}>{letter}</div>
+                        <div key={letter} style={labelCellStyle}>{letter}</div>
                     ))}
                 </div>
                 {/* The board */}
                 <div style={{
                     position: 'relative',
-                    outline: `${isMobile ? 0.2 : 0.1}vw solid rgb(40, 18, 0)`,
+                    outline: `${isMobile ? 0.2 : 0.1}vw solid ${FRAME_BEVEL_DARK}`,
                 }}>
                 <Background 
                     possibleCaptures={possibleCaptures}

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -102,7 +102,7 @@ const HUD = (props) => {
                 fontFamily: 'Basic',
                 color: 'white',
                 marginTop: `${isMobile ? 1 : 0.5}vw`,
-                width: isMobile ? '59.2vw' : '29.6vw',
+                width: isMobile ? '65.0vw' : '32.5vw',
                 boxSizing: 'border-box'
             }}>
                 <div style={{

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -38,12 +38,6 @@
     justify-content: space-between;
 }
 
-.label {
-    margin: 0;
-    font-weight: 1000;
-    font-size: 1.5vw;
-}
-
 .regular_piece {
     position: absolute;
     width: 1.8vw;
@@ -247,12 +241,6 @@ progress {
         justify-content: space-between;
     }
 
-    .label {
-        margin: 0;
-        font-weight: 1000;
-        font-size: 3vw;
-    }
-    
     .regular_piece {
         position: absolute;
         width: 3.6vw;


### PR DESCRIPTION
## Summary
- Adds a pixel-art wooden frame around the chess board using the same brown palette as the HUD
- Moves coordinate labels (8-1, a-h) from inside board squares to the frame gutter for a cleaner look
- Fixes asymmetric spacing between captured pieces sections and the board
- Updates HUD width to match the new framed board dimensions
- Removes unused `.label` CSS class

## Test plan
- [x] Desktop: frame renders with brown border, bevel effect, and coordinate labels in gutter
- [x] Desktop: pieces align correctly within the framed board
- [x] Desktop: HUD aligns with framed board width
- [x] Desktop: overlays (Victory/Defeat/Draw) still center correctly
- [x] Desktop: all piece UI indicators (buffs, debuffs, stunned, etc.) render correctly
- [x] Mobile: responsive sizing, labels readable, frame proportional
- [x] Captured pieces sections have symmetrical spacing above/below the board

🤖 Generated with [Claude Code](https://claude.com/claude-code)