### PR TITLE
Add game move logging and bug report feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,6 @@ docker compose up mongo
 | POST | `/api/game` | Create new game |
 | GET | `/api/game/{id}` | Get game state |
 | PUT | `/api/game/{id}` | Submit move (update game state) |
-| DELETE | `/api/game/{id}` | Delete game |
 
 ## Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,6 @@ docker compose up mongo
 | POST | `/api/game` | Create new game |
 | GET | `/api/game/{id}` | Get game state |
 | PUT | `/api/game/{id}` | Submit move (update game state) |
-| DELETE | `/api/game/{id}` | Delete game |
 
 ## Conventions
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -39,7 +39,6 @@ docker compose up mongo
 | POST | `/api/game` | Create new game |
 | GET | `/api/game/{id}` | Get game state |
 | PUT | `/api/game/{id}` | Submit move (update game state) |
-| DELETE | `/api/game/{id}` | Delete game |
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Spawns on the a5 square every 15 turns after the 20th turn. Grants a 4-turn buff
     - rudimentary EASY enemy AI (chooses random moves from possible moves)
     - ADVANCED enemy AI that plays as well as possible
     - MEDIUM enemy AI
+* Log moves to a `game_moves` collection for full game history and bug report tracing
 * provide mechanism for user bug reports (frontend sends game id and user feedback to backend and backend records info)
 
 ##### Production-Ready Development

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -135,6 +135,29 @@ def update_game_state(id: str, state: GameStateRequest, response: Response, play
     return retrieve_game_state(id, response)
 
 
+class BugReportRequest(BaseModel):
+    game_id: str
+    turn: int
+    description: str = ""
+    region: str = ""
+
+
+@router.post("/bug-report", status_code=201)
+def create_bug_report(report: BugReportRequest) -> dict:
+    """Submit a bug report and persist to MongoDB."""
+    bug_report = {
+        "game_id": report.game_id,
+        "turn": report.turn,
+        "description": report.description,
+        "region": report.region,
+        "timestamp": datetime.datetime.now(),
+    }
+    game_database = mongo_client["game_db"]
+    game_database["bug_reports"].insert_one(bug_report)
+    bug_report["id"] = str(bug_report.pop("_id"))
+    return bug_report
+
+
 def update_game_state_no_restrictions(id: str, state: GameStateRequest, response: Response) -> dict:
     """Overwrite a game state without validation (testing only, not exposed via API)."""
     new_game_state = dict(state)

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -150,7 +150,7 @@ def create_bug_report(report: BugReportRequest) -> dict:
         "turn": report.turn,
         "description": report.description,
         "region": report.region,
-        "timestamp": datetime.datetime.now(),
+        "timestamp": datetime.datetime.now(datetime.timezone.utc),
     }
     game_database = mongo_client["game_db"]
     game_database["bug_reports"].insert_one(bug_report)

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -72,15 +72,6 @@ def retrieve_game_state(id: str, response: Response) -> dict:
     return game_state
 
 
-@router.delete("/game/{id}")
-def delete_game(id: str) -> dict:
-    """Delete a game from MongoDB by ID."""
-    query = {"_id": ObjectId(id)}
-    game_database = mongo_client["game_db"]
-    game_database["games"].delete_one(query)
-    return {"message": "Success"}
-
-
 @router.put("/game/{id}", status_code=200)
 def update_game_state(id: str, state: GameStateRequest, response: Response, player: bool = True) -> dict:
     """Validate and apply a full game state update (the main turn pipeline)."""

--- a/backend/src/utils/game_update_pipeline.py
+++ b/backend/src/utils/game_update_pipeline.py
@@ -303,7 +303,7 @@ def finalize_game_state(old_game_state: GameState, new_game_state: GameState, mo
                 for mp in moved_pieces
             ],
             "captured_pieces": new_game_state["captured_pieces"],
-            "timestamp": datetime.datetime.now()
+            "timestamp": datetime.datetime.now(datetime.timezone.utc)
         }
         mongo_client["game_db"]["game_moves"].insert_one(move_log)
 

--- a/backend/src/utils/game_update_pipeline.py
+++ b/backend/src/utils/game_update_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import Callable, TYPE_CHECKING
 
 from fastapi import HTTPException, Response
@@ -286,7 +287,26 @@ def finalize_game_state(old_game_state: GameState, new_game_state: GameState, mo
     """Record moves, set position in play, compute legal moves, handle draws/items, and persist."""
     # Record movement
     utils.record_moved_pieces_this_turn(new_game_state, moved_pieces)
-    
+
+    # Log move to game_moves collection
+    if moved_pieces:
+        move_log = {
+            "game_id": id,
+            "turn": new_game_state["turn_count"],
+            "side": "white" if player else "black",
+            "moved_pieces": [
+                {
+                    "piece_type": mp["piece"]["type"],
+                    "from": mp["previous_position"],
+                    "to": mp["current_position"]
+                }
+                for mp in moved_pieces
+            ],
+            "captured_pieces": new_game_state["captured_pieces"],
+            "timestamp": datetime.datetime.now()
+        }
+        mongo_client["game_db"]["game_moves"].insert_one(move_log)
+
     # Position in play logic
     reset_position_in_play_queen = True
     if new_game_state["queen_reset"]:

--- a/backend/src/utils/game_update_pipeline.py
+++ b/backend/src/utils/game_update_pipeline.py
@@ -288,25 +288,6 @@ def finalize_game_state(old_game_state: GameState, new_game_state: GameState, mo
     # Record movement
     utils.record_moved_pieces_this_turn(new_game_state, moved_pieces)
 
-    # Log move to game_moves collection
-    if moved_pieces:
-        move_log = {
-            "game_id": id,
-            "turn": new_game_state["turn_count"],
-            "side": "white" if player else "black",
-            "moved_pieces": [
-                {
-                    "piece_type": mp["piece"]["type"],
-                    "from": mp["previous_position"],
-                    "to": mp["current_position"]
-                }
-                for mp in moved_pieces
-            ],
-            "captured_pieces": new_game_state["captured_pieces"],
-            "timestamp": datetime.datetime.now(datetime.timezone.utc)
-        }
-        mongo_client["game_db"]["game_moves"].insert_one(move_log)
-
     # Position in play logic
     reset_position_in_play_queen = True
     if new_game_state["queen_reset"]:
@@ -326,6 +307,25 @@ def finalize_game_state(old_game_state: GameState, new_game_state: GameState, mo
     # Final management and persistence
     utils.manage_game_state(old_game_state, new_game_state)
     utils.perform_game_state_update(new_game_state, mongo_client, id)
+
+    # Log move to game_moves collection (after persistence to avoid phantom entries)
+    if moved_pieces:
+        move_log = {
+            "game_id": id,
+            "turn": new_game_state["turn_count"],
+            "side": "white" if player else "black",
+            "moved_pieces": [
+                {
+                    "piece_type": mp["piece"]["type"],
+                    "from": mp["previous_position"],
+                    "to": mp["current_position"]
+                }
+                for mp in moved_pieces
+            ],
+            "captured_pieces": new_game_state["captured_pieces"],
+            "timestamp": datetime.datetime.now(datetime.timezone.utc)
+        }
+        mongo_client["game_db"]["game_moves"].insert_one(move_log)
 
 
 def unmark_all_pieces_marked_for_death(new_game_state: GameState) -> None:

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,28 +1,15 @@
 import pytest
-import time
-from fastapi import Response
+from bson.objectid import ObjectId
+
 import src.api as api
+from src.database import mongo_client
 
 
 @pytest.fixture
 def game():
     game = api.create_game()
     yield game
-    
-    result = api.delete_game(game["id"])
-    assert result.get("message") == "Success"
-    
-    # Poll until game is actually deleted (max 10 seconds)
-    max_wait = 10
-    poll_interval = 0.1
-    elapsed = 0
-    
-    while elapsed < max_wait:
-        response = api.retrieve_game_state(game["id"], Response())
-        if "not found" in response.get("message", ""):
-            break  # Game successfully deleted
-        time.sleep(poll_interval)
-        elapsed += poll_interval
-    
-    # Final assertion to ensure game was deleted
-    assert "not found" in api.retrieve_game_state(game["id"], Response()).get("message", "")
+
+    game_database = mongo_client["game_db"]
+    game_database["games"].delete_one({"_id": ObjectId(game["id"])})
+    game_database["game_moves"].delete_many({"game_id": game["id"]})

--- a/backend/tests/integration/test_bug_report.py
+++ b/backend/tests/integration/test_bug_report.py
@@ -1,40 +1,36 @@
+import pytest
 from bson.objectid import ObjectId
 
 import src.api as api
 from src.database import mongo_client
 
 
-def test_bug_report_with_description():
-    report = api.create_bug_report(api.BugReportRequest(
-        game_id="abc123",
-        turn=5,
-        description="Pawn disappeared after capture",
-        region="America/New_York"
-    ))
-
-    try:
-        assert "id" in report
-        assert report["game_id"] == "abc123"
-        assert report["turn"] == 5
-        assert report["description"] == "Pawn disappeared after capture"
-        assert report["region"] == "America/New_York"
-        assert "timestamp" in report
-    finally:
-        mongo_client["game_db"]["bug_reports"].delete_one({"_id": ObjectId(report["id"])})
+@pytest.fixture
+def bug_report(request):
+    report = api.create_bug_report(api.BugReportRequest(**request.param))
+    yield report
+    mongo_client["game_db"]["bug_reports"].delete_one({"_id": ObjectId(report["id"])})
 
 
-def test_bug_report_with_empty_description():
-    report = api.create_bug_report(api.BugReportRequest(
-        game_id="def456",
-        turn=12
-    ))
+@pytest.mark.parametrize("bug_report", [
+    {"game_id": "abc123", "turn": 5, "description": "Pawn disappeared after capture", "region": "America/New_York"}
+], indirect=True)
+def test_bug_report_with_description(bug_report):
+    assert "id" in bug_report
+    assert bug_report["game_id"] == "abc123"
+    assert bug_report["turn"] == 5
+    assert bug_report["description"] == "Pawn disappeared after capture"
+    assert bug_report["region"] == "America/New_York"
+    assert "timestamp" in bug_report
 
-    try:
-        assert "id" in report
-        assert report["game_id"] == "def456"
-        assert report["turn"] == 12
-        assert report["description"] == ""
-        assert report["region"] == ""
-        assert "timestamp" in report
-    finally:
-        mongo_client["game_db"]["bug_reports"].delete_one({"_id": ObjectId(report["id"])})
+
+@pytest.mark.parametrize("bug_report", [
+    {"game_id": "def456", "turn": 12}
+], indirect=True)
+def test_bug_report_with_empty_description(bug_report):
+    assert "id" in bug_report
+    assert bug_report["game_id"] == "def456"
+    assert bug_report["turn"] == 12
+    assert bug_report["description"] == ""
+    assert bug_report["region"] == ""
+    assert "timestamp" in bug_report

--- a/backend/tests/integration/test_bug_report.py
+++ b/backend/tests/integration/test_bug_report.py
@@ -1,0 +1,40 @@
+from bson.objectid import ObjectId
+
+import src.api as api
+from src.database import mongo_client
+
+
+def test_bug_report_with_description():
+    report = api.create_bug_report(api.BugReportRequest(
+        game_id="abc123",
+        turn=5,
+        description="Pawn disappeared after capture",
+        region="America/New_York"
+    ))
+
+    try:
+        assert "id" in report
+        assert report["game_id"] == "abc123"
+        assert report["turn"] == 5
+        assert report["description"] == "Pawn disappeared after capture"
+        assert report["region"] == "America/New_York"
+        assert "timestamp" in report
+    finally:
+        mongo_client["game_db"]["bug_reports"].delete_one({"_id": ObjectId(report["id"])})
+
+
+def test_bug_report_with_empty_description():
+    report = api.create_bug_report(api.BugReportRequest(
+        game_id="def456",
+        turn=12
+    ))
+
+    try:
+        assert "id" in report
+        assert report["game_id"] == "def456"
+        assert report["turn"] == 12
+        assert report["description"] == ""
+        assert report["region"] == ""
+        assert "timestamp" in report
+    finally:
+        mongo_client["game_db"]["bug_reports"].delete_one({"_id": ObjectId(report["id"])})

--- a/backend/tests/integration/test_move_logging.py
+++ b/backend/tests/integration/test_move_logging.py
@@ -1,0 +1,101 @@
+import copy
+from fastapi import Response
+
+import src.api as api
+from src.database import mongo_client
+from tests.test_utils import (
+    select_white_piece,
+    select_and_move_white_piece,
+    select_and_move_black_piece,
+)
+
+
+def test_move_history_accumulates(game):
+    game_id = game["id"]
+
+    # Turn 1: white pawn a2 -> a3 (row 6, col 0 -> row 5, col 0)
+    game = select_and_move_white_piece(game, 6, 0, 5, 0)
+
+    # Turn 2: black pawn a7 -> a6 (row 1, col 0 -> row 2, col 0)
+    game = select_and_move_black_piece(game, 1, 0, 2, 0)
+
+    # Turn 3: white pawn b2 -> b3 (row 6, col 1 -> row 5, col 1)
+    game = select_and_move_white_piece(game, 6, 1, 5, 1)
+
+    # Query move logs
+    move_logs = list(
+        mongo_client["game_db"]["game_moves"]
+        .find({"game_id": game_id})
+        .sort("turn", 1)
+    )
+
+    # Should have 3 move log entries (one per move that moves a piece)
+    assert len(move_logs) == 3
+
+    # Verify structure and content of each entry
+    for entry in move_logs:
+        assert "game_id" in entry
+        assert "turn" in entry
+        assert "side" in entry
+        assert "moved_pieces" in entry
+        assert "captured_pieces" in entry
+        assert "timestamp" in entry
+        assert entry["game_id"] == game_id
+
+    # Sides alternate white/black/white
+    assert move_logs[0]["side"] == "white"
+    assert move_logs[1]["side"] == "black"
+    assert move_logs[2]["side"] == "white"
+
+    # Turn numbers increment
+    assert move_logs[0]["turn"] < move_logs[1]["turn"]
+    assert move_logs[1]["turn"] < move_logs[2]["turn"]
+
+    # Verify moved_pieces content
+    # White pawn a2->a3
+    assert len(move_logs[0]["moved_pieces"]) == 1
+    assert "pawn" in move_logs[0]["moved_pieces"][0]["piece_type"]
+    assert move_logs[0]["moved_pieces"][0]["from"] == [6, 0]
+    assert move_logs[0]["moved_pieces"][0]["to"] == [5, 0]
+
+    # Black pawn a7->a6
+    assert len(move_logs[1]["moved_pieces"]) == 1
+    assert "pawn" in move_logs[1]["moved_pieces"][0]["piece_type"]
+    assert move_logs[1]["moved_pieces"][0]["from"] == [1, 0]
+    assert move_logs[1]["moved_pieces"][0]["to"] == [2, 0]
+
+    # White pawn b2->b3
+    assert len(move_logs[2]["moved_pieces"]) == 1
+    assert "pawn" in move_logs[2]["moved_pieces"][0]["piece_type"]
+    assert move_logs[2]["moved_pieces"][0]["from"] == [6, 1]
+    assert move_logs[2]["moved_pieces"][0]["to"] == [5, 1]
+
+
+def test_capture_logged_in_captured_pieces(game):
+    game_id = game["id"]
+
+    # White pawn d2->d4
+    game = select_and_move_white_piece(game, 6, 3, 4, 3)
+    # Black pawn e7->e5
+    game = select_and_move_black_piece(game, 1, 4, 3, 4)
+
+    # White pawn d4 captures black pawn on e5: select piece first
+    game = select_white_piece(game, 4, 3)
+
+    # Manually construct the capture move
+    game_on_next_turn = copy.deepcopy(game)
+    game_on_next_turn["board_state"][3][4] = game_on_next_turn["board_state"][4][3]
+    game_on_next_turn["board_state"][4][3] = None
+    game_on_next_turn["captured_pieces"]["white"].append("black_pawn")
+    game_state = api.GameStateRequest(**game_on_next_turn)
+    game = api.update_game_state(game["id"], game_state, Response())
+
+    move_logs = list(
+        mongo_client["game_db"]["game_moves"]
+        .find({"game_id": game_id})
+        .sort("turn", 1)
+    )
+
+    # The capture move (last entry) should have the captured piece in captured_pieces
+    capture_entry = move_logs[-1]
+    assert "black_pawn" in capture_entry["captured_pieces"]["white"]

--- a/frontend/src/components/BugReportForm.js
+++ b/frontend/src/components/BugReportForm.js
@@ -8,10 +8,15 @@ const BugReportForm = ({ onClose }) => {
     const isMobile = useIsMobile()
     const [description, setDescription] = useState('')
     const [submitted, setSubmitted] = useState(false)
+    const [submitting, setSubmitting] = useState(false)
+    const [error, setError] = useState(null)
 
     const handleSubmit = () => {
-        const gameId = sessionStorage.getItem("gameStateId")
+        const gameId = sessionStorage.getItem("gameStateId") ?? ""
         const region = Intl.DateTimeFormat().resolvedOptions().timeZone || ""
+
+        setSubmitting(true)
+        setError(null)
 
         fetch(`${BASE_API_URL}/api/bug-report`, {
             method: 'POST',
@@ -28,7 +33,11 @@ const BugReportForm = ({ onClose }) => {
             setSubmitted(true)
             setTimeout(() => onClose(), 1500)
         })
-        .catch(err => console.log(err))
+        .catch(err => {
+            console.log(err)
+            setError('Submission failed. Please try again.')
+            setSubmitting(false)
+        })
     }
 
     return (
@@ -86,28 +95,35 @@ const BugReportForm = ({ onClose }) => {
                     <div style={{
                         display: 'flex',
                         alignItems: 'center',
-                        justifyContent: 'flex-end',
+                        justifyContent: 'space-between',
                         padding: `${isMobile ? 1 : 0.5}vw ${isMobile ? 1.5 : 0.75}vw`,
-                        gap: `${isMobile ? 1 : 0.5}vw`
                     }}>
-                        <button
-                            className="pixel-btn"
-                            onClick={onClose}
-                            style={{
-                                fontSize: `${isMobile ? 1.5 : 0.75}vw`,
-                                padding: `${isMobile ? 0.5 : 0.25}vw ${isMobile ? 1 : 0.5}vw`,
-                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`
-                            }}
-                        >Cancel</button>
-                        <button
-                            className="pixel-btn"
-                            onClick={handleSubmit}
-                            style={{
-                                fontSize: `${isMobile ? 1.5 : 0.75}vw`,
-                                padding: `${isMobile ? 0.5 : 0.25}vw ${isMobile ? 1 : 0.5}vw`,
-                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`
-                            }}
-                        >Submit</button>
+                        {error ?
+                            <span style={{ fontSize: `${isMobile ? 1.4 : 0.7}vw`, color: 'rgb(230, 60, 60)' }}>{error}</span> :
+                            <span />
+                        }
+                        <div style={{ display: 'flex', gap: `${isMobile ? 1 : 0.5}vw` }}>
+                            <button
+                                className="pixel-btn"
+                                onClick={onClose}
+                                style={{
+                                    fontSize: `${isMobile ? 1.5 : 0.75}vw`,
+                                    padding: `${isMobile ? 0.5 : 0.25}vw ${isMobile ? 1 : 0.5}vw`,
+                                    borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                                }}
+                            >Cancel</button>
+                            <button
+                                className="pixel-btn"
+                                onClick={handleSubmit}
+                                disabled={submitting}
+                                style={{
+                                    fontSize: `${isMobile ? 1.5 : 0.75}vw`,
+                                    padding: `${isMobile ? 0.5 : 0.25}vw ${isMobile ? 1 : 0.5}vw`,
+                                    borderRadius: `${isMobile ? 0.6 : 0.3}vw`,
+                                    opacity: submitting ? 0.5 : 1
+                                }}
+                            >{submitting ? "Sending..." : "Submit"}</button>
+                        </div>
                     </div>
                 </>
             )}

--- a/frontend/src/components/BugReportForm.js
+++ b/frontend/src/components/BugReportForm.js
@@ -38,6 +38,7 @@ const BugReportForm = ({ onClose }) => {
                 width: `${isMobile ? 65.0 : 32.5}vw`,
                 marginTop: `${isMobile ? 3 : 1.5}vw`,
                 borderWidth: `${isMobile ? 2.5 : 1.25}vw`,
+                borderTopWidth: `${isMobile ? 0.8 : 0.4}vw`,
                 boxSizing: 'border-box',
             }}
         >

--- a/frontend/src/components/BugReportForm.js
+++ b/frontend/src/components/BugReportForm.js
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { GameStateContextData } from '../context/GameStateContext';
+import { BASE_API_URL, useIsMobile } from '../utility';
+
+
+const BugReportForm = ({ onClose }) => {
+    const gameState = GameStateContextData()
+    const isMobile = useIsMobile()
+    const [description, setDescription] = useState('')
+    const [submitted, setSubmitted] = useState(false)
+
+    const handleSubmit = () => {
+        const gameId = sessionStorage.getItem("gameStateId")
+        const region = Intl.DateTimeFormat().resolvedOptions().timeZone || ""
+
+        fetch(`${BASE_API_URL}/api/bug-report`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                game_id: gameId,
+                turn: gameState.turnCount,
+                description: description,
+                region: region
+            })
+        })
+        .then(response => {
+            if (!response.ok) throw new Error('Failed to submit bug report')
+            setSubmitted(true)
+            setTimeout(() => onClose(), 1500)
+        })
+        .catch(err => console.log(err))
+    }
+
+    return (
+        <div
+            className="pixel-panel"
+            style={{
+                width: `${isMobile ? 65.0 : 32.5}vw`,
+                marginTop: `${isMobile ? 3 : 1.5}vw`,
+                borderWidth: `${isMobile ? 2.5 : 1.25}vw`,
+                boxSizing: 'border-box',
+            }}
+        >
+            <div style={{
+                backgroundColor: 'rgb(71, 33, 1)',
+                padding: `${isMobile ? 1 : 0.5}vw 0`,
+                textAlign: 'center'
+            }}>
+                <p style={{
+                    fontFamily: 'Basic',
+                    fontSize: `${isMobile ? 3 : 1.5}vw`,
+                    margin: 0
+                }}>~ Bug Report ~</p>
+            </div>
+            {submitted ? (
+                <div style={{
+                    padding: `${isMobile ? 3 : 1.5}vw`,
+                    textAlign: 'center',
+                    fontSize: `${isMobile ? 2.5 : 1.25}vw`,
+                    color: 'rgb(80, 220, 80)'
+                }}>
+                    Sent!
+                </div>
+            ) : (
+                <>
+                    <div style={{
+                        padding: `${isMobile ? 2 : 1}vw`,
+                        borderBottom: `${isMobile ? 0.3 : 0.15}vw solid rgb(71, 33, 1)`
+                    }}>
+                        <textarea
+                            className="bug-report-textarea"
+                            placeholder="Describe the bug (optional)"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                            rows={3}
+                            style={{
+                                width: '100%',
+                                fontSize: `${isMobile ? 2 : 1}vw`,
+                                padding: `${isMobile ? 1 : 0.5}vw`,
+                                boxSizing: 'border-box',
+                                resize: 'vertical'
+                            }}
+                        />
+                    </div>
+                    <div style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'flex-end',
+                        padding: `${isMobile ? 1 : 0.5}vw ${isMobile ? 1.5 : 0.75}vw`,
+                        gap: `${isMobile ? 1 : 0.5}vw`
+                    }}>
+                        <button
+                            className="pixel-btn"
+                            onClick={onClose}
+                            style={{
+                                fontSize: `${isMobile ? 1.5 : 0.75}vw`,
+                                padding: `${isMobile ? 0.5 : 0.25}vw ${isMobile ? 1 : 0.5}vw`,
+                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                            }}
+                        >Cancel</button>
+                        <button
+                            className="pixel-btn"
+                            onClick={handleSubmit}
+                            style={{
+                                fontSize: `${isMobile ? 1.5 : 0.75}vw`,
+                                padding: `${isMobile ? 0.5 : 0.25}vw ${isMobile ? 1 : 0.5}vw`,
+                                borderRadius: `${isMobile ? 0.6 : 0.3}vw`
+                            }}
+                        >Submit</button>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+export default BugReportForm;

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -77,7 +77,7 @@ const HUD = (props) => {
     const handleBugReportButtonClick = () => {
         setToggleBugReport(!toggleBugReport)
         setToggleShop(false)
-        props.setShopPieceSelected(null)
+        props.setShopPieceSelected?.(null)
     }
 
     const isWhiteTurn = turnCount % 2 === 0

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -2,6 +2,7 @@ import React, {useState, useEffect, useRef} from 'react';
 import { GameStateContextData } from '../context/GameStateContext';
 import { IMAGE_MAP, PLAYERS, useIsMobile } from '../utility';
 import Shop from './Shop';
+import BugReportForm from './BugReportForm';
 
 
 const HUD = (props) => {
@@ -13,6 +14,7 @@ const HUD = (props) => {
     const enemyGoldCount = gameState.goldCount?.[PLAYERS[1]] || 0
     const isMobile = useIsMobile()
     const [toggleShop, setToggleShop] = useState(false)
+    const [toggleBugReport, setToggleBugReport] = useState(false)
     const [showRestartConfirm, setShowRestartConfirm] = useState(false)
     const [turnFlashClass, setTurnFlashClass] = useState('')
     const prevTurnCount = useRef(turnCount)
@@ -69,6 +71,13 @@ const HUD = (props) => {
 
     const handleShopButtonClick = () => {
         setToggleShop(!toggleShop)
+        setToggleBugReport(false)
+    }
+
+    const handleBugReportButtonClick = () => {
+        setToggleBugReport(!toggleBugReport)
+        setToggleShop(false)
+        props.setShopPieceSelected(null)
     }
 
     const isWhiteTurn = turnCount % 2 === 0
@@ -146,26 +155,33 @@ const HUD = (props) => {
                             <span style={{ color: 'rgb(180, 180, 180)' }}>{enemyGoldCount}</span>
                         </div>
                     </div>
-                    {showRestartConfirm ?
-                        <div style={{ display: 'flex', gap: `${isMobile ? 0.6 : 0.3}vw`, alignItems: 'center' }}>
-                            <span style={{ fontSize: `${isMobile ? 1.4 : 0.7}vw`, opacity: 0.8 }}>Restart?</span>
-                            <button
-                                className="pixel-btn"
-                                onClick={handleConfirmRestart}
-                                style={confirmBtnStyle}
-                            >Yes</button>
-                            <button
-                                className="pixel-btn"
-                                onClick={() => setShowRestartConfirm(false)}
-                                style={confirmBtnStyle}
-                            >No</button>
-                        </div> :
+                    <div style={{ display: 'flex', gap: `${isMobile ? 0.6 : 0.3}vw`, alignItems: 'center' }}>
                         <button
                             className="pixel-btn"
-                            onClick={() => setShowRestartConfirm(true)}
+                            onClick={handleBugReportButtonClick}
                             style={{...confirmBtnStyle, opacity: 0.7}}
-                        >Restart</button>
-                    }
+                        >{toggleBugReport ? "Close" : "Report Bug"}</button>
+                        {showRestartConfirm ?
+                            <>
+                                <span style={{ fontSize: `${isMobile ? 1.4 : 0.7}vw`, opacity: 0.8 }}>Restart?</span>
+                                <button
+                                    className="pixel-btn"
+                                    onClick={handleConfirmRestart}
+                                    style={confirmBtnStyle}
+                                >Yes</button>
+                                <button
+                                    className="pixel-btn"
+                                    onClick={() => setShowRestartConfirm(false)}
+                                    style={confirmBtnStyle}
+                                >No</button>
+                            </> :
+                            <button
+                                className="pixel-btn"
+                                onClick={() => setShowRestartConfirm(true)}
+                                style={{...confirmBtnStyle, opacity: 0.7}}
+                            >Restart</button>
+                        }
+                    </div>
                 </div>
             </div>
             {
@@ -174,6 +190,11 @@ const HUD = (props) => {
                     shopPieceSelected={props.shopPieceSelected}
                     setShopPieceSelected={props.setShopPieceSelected}
                  /> :
+                 null
+            }
+            {
+                toggleBugReport ?
+                 <BugReportForm onClose={() => setToggleBugReport(false)} /> :
                  null
             }
         </div>

--- a/frontend/src/components/Shop.js
+++ b/frontend/src/components/Shop.js
@@ -17,6 +17,7 @@ const Shop = (props) => {
                 width: `${isMobile ? 65.0 : 32.5}vw`,
                 marginTop: `${isMobile ? 3 : 1.5}vw`,
                 borderWidth: `${isMobile ? 2.5 : 1.25}vw`,
+                borderTopWidth: `${isMobile ? 0.8 : 0.4}vw`,
                 boxSizing: 'border-box',
             }}
         >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -209,6 +209,18 @@ progress {
     font-size: 0.25vw;
 }
 
+.bug-report-textarea {
+    font-family: "Basic";
+    background-color: rgb(71, 33, 1);
+    color: white;
+    border: 0.15vw solid rgb(50, 23, 0);
+    outline: none;
+}
+
+.bug-report-textarea::placeholder {
+    color: rgb(180, 160, 140);
+}
+
 @keyframes turn-flash-green {
     0% { color: white; transform: scale(1); }
     20% { color: rgb(80, 220, 80); transform: scale(1.4); }


### PR DESCRIPTION
## Summary
- Log every move to a `game_moves` MongoDB collection for bug report tracing (game_id, turn, side, moved pieces, captured pieces, timestamp)
- Add bug report feature: POST `/api/bug-report` endpoint + HUD button that opens a panel (same style as Shop) where players can describe the bug — auto-captures game ID, turn, browser timezone, and timestamp
- Remove unused DELETE `/api/game/{id}` endpoint and simplify test fixture cleanup
- Reduce top border on Shop and Bug Report panels for better visual balance

## Test plan
- [x] All 212 tests pass (`PYTHONPATH="$PWD/backend" pytest -n auto`)
- [x] Move logging integration tests verify log accumulation and capture tracking
- [x] Bug report integration tests verify persistence with and without description
- [x] Manual test: submitted bug report via HUD, verified in MongoDB via `mongosh`