### PR TITLE
Fix castle buttons showing for wrong side

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ PYTHONPATH="$PWD/backend" pytest -v -s -x -k "dragon"            # verbose, prin
 docker compose up --build
 
 # Docker Compose (MongoDB only, for local dev)
+# If this fails with "Cannot connect to the Docker daemon", start Docker Desktop first:
+#   open -a "Docker Desktop"
+# Then wait a few seconds for the daemon to be ready before retrying.
 docker compose up mongo
 ```
 

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -168,8 +168,9 @@ const Board = () => {
                                                         markedForDeath={piece.markedForDeath}
                                                         boardHeraldBuff={piece.boardHeraldBuff}
                                                         neutralBuffLog={gameState.neutralBuffLog}
-                                                        // Only white king gets castle buttons; black castling is handled by AI
-                                                        castleMoves={piece.type === "white_king" ? castleMoves : []}
+                                                        castleMoves={piece.type === "white_king" ? castleMoves.filter(m => m[0] === 7)
+                                                            : piece.type === "black_king" ? castleMoves.filter(m => m[0] === 0)
+                                                            : []}
                                                     />
                                                 );
                                         }));

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -449,9 +449,8 @@ const Piece = (props) => {
             {
                 props.castleMoves?.length > 0 ?
                 <div>
-                    {props.castleMoves.map((move) => {
+                    {(() => { const isBlack = props.side === 'black'; return props.castleMoves.map((move) => {
                         const isQueenside = move[1] === 2
-                        const isBlack = props.side === 'black'
                         return (
                             <button
                                 key={`castle-${move[1]}`}
@@ -470,7 +469,7 @@ const Piece = (props) => {
                                 disabled={isBlack}
                             >{isQueenside ? "Castle Left" : "Castle Right"}</button>
                         )
-                    })}
+                    })})()}
                 </div>
                 : null
             }

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -463,7 +463,7 @@ const Piece = (props) => {
                                     ),
                                     fontSize: `${isMobile ? 1.4 : 0.7}vw`,
                                     cursor: isBlack ? 'default' : 'pointer',
-                                    opacity: isBlack ? 0.9 : 1,
+                                    opacity: isBlack ? 0.7 : 1,
                                 }}
                                 onClick={isBlack ? undefined : () => handleCastleButtonClick(move)}
                                 disabled={isBlack}

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -3,10 +3,11 @@ import React from 'react';
 import  { updateGameState, GameStateContextData }  from '../context/GameStateContext';
 
 import { 
-    PLAYERS, 
-    IMAGE_MAP, 
-    MAX_BOSS_HEALTH, 
-    useIsMobile, 
+    PLAYERS,
+    IMAGE_MAP,
+    MAX_BOSS_HEALTH,
+    CASTLE_BUTTON_COLORS,
+    useIsMobile,
     snakeToCamel,
     camelToSnake
 } from '../utility';
@@ -458,8 +459,8 @@ const Piece = (props) => {
                                     ...pieceActionBtnStyle(
                                         -(isMobile ? 2.5 : 1.25),
                                         isQueenside ? -(isMobile ? 8 : 4) : (isMobile ? 5.5 : 2.75),
-                                        isBlack ? '#f26363' : '#63bbf2',
-                                        isBlack ? '#ed2424' : '#24a0ed'
+                                        CASTLE_BUTTON_COLORS[isBlack ? 'black' : 'white'][0],
+                                        CASTLE_BUTTON_COLORS[isBlack ? 'black' : 'white'][1]
                                     ),
                                     fontSize: `${isMobile ? 1.4 : 0.7}vw`,
                                     cursor: isBlack ? 'default' : 'pointer',

--- a/frontend/src/components/Piece.js
+++ b/frontend/src/components/Piece.js
@@ -450,6 +450,7 @@ const Piece = (props) => {
                 <div>
                     {props.castleMoves.map((move) => {
                         const isQueenside = move[1] === 2
+                        const isBlack = props.side === 'black'
                         return (
                             <button
                                 key={`castle-${move[1]}`}
@@ -457,11 +458,15 @@ const Piece = (props) => {
                                     ...pieceActionBtnStyle(
                                         -(isMobile ? 2.5 : 1.25),
                                         isQueenside ? -(isMobile ? 8 : 4) : (isMobile ? 5.5 : 2.75),
-                                        '#63bbf2', '#24a0ed'
+                                        isBlack ? '#f26363' : '#63bbf2',
+                                        isBlack ? '#ed2424' : '#24a0ed'
                                     ),
                                     fontSize: `${isMobile ? 1.4 : 0.7}vw`,
+                                    cursor: isBlack ? 'default' : 'pointer',
+                                    opacity: isBlack ? 0.9 : 1,
                                 }}
-                                onClick={() => handleCastleButtonClick(move)}
+                                onClick={isBlack ? undefined : () => handleCastleButtonClick(move)}
+                                disabled={isBlack}
                             >{isQueenside ? "Castle Left" : "Castle Right"}</button>
                         )
                     })}

--- a/frontend/src/utility.js
+++ b/frontend/src/utility.js
@@ -87,6 +87,10 @@ const BOSS_SQUARE_COLORS = {
     "board_herald": ["rgb(79, 22, 144)", "rgb(134, 73, 203)"],
     "baron_nashor": ["rgb(45, 13, 81)", "rgb(97, 61, 138)"]
 }
+const CASTLE_BUTTON_COLORS = {
+    white: ['#63bbf2', '#24a0ed'],
+    black: ['#f26363', '#ed2424']
+}
 const UNSAFE_KING_SQUARE_COLOR = "rgba(186, 0, 0, 0.3)"
 const LIGHT_BLUE_SQUARE_COLOR = "rgb(102, 216, 242)"
 const WHITE_SHOP_SQUARE_COLOR = "rgb(51, 171, 55)"
@@ -365,6 +369,7 @@ export {
     BARON_NASHOR_POSITION,
     MAX_BOSS_HEALTH,
     LIGHT_BLUE_SQUARE_COLOR,
+    CASTLE_BUTTON_COLORS,
     UNSAFE_KING_SQUARE_COLOR,
     BASE_API_URL,
     getPiecePrice,


### PR DESCRIPTION
## Summary
- **Bug fix:** Castle moves computed for black's turn were incorrectly displayed on the white king (e.g., "Castle Left" appearing when white was clearly ineligible to castle)
- **Enhancement:** Black king now shows red, unclickable castle indicator buttons so the player can see the opponent's castling availability
- **Docs:** Added Docker Desktop startup instructions to CLAUDE.md for when the Docker daemon isn't running

🤖 Generated with [Claude Code](https://claude.com/claude-code)