### PR TITLE
Prevent queen stun from affecting neutral monsters

### DIFF
--- a/backend/src/utils/piece_mechanics.py
+++ b/backend/src/utils/piece_mechanics.py
@@ -85,7 +85,7 @@ def apply_queen_stun(old_game_state: GameState, new_game_state: GameState, moved
                     if square:
                         for piece in square:
                             side = piece["type"].split("_")[0]
-                            if queen_side != side and "king" not in piece["type"]:
+                            if queen_side != side and "king" not in piece["type"] and side != "neutral":
                                 piece["is_stunned"] = True
                                 piece["turn_stunned_for"] = old_game_state["turn_count"] + 1
 

--- a/backend/tests/integration/test_api_queen_mechanics.py
+++ b/backend/tests/integration/test_api_queen_mechanics.py
@@ -324,3 +324,48 @@ def test_skip_one_turn_if_all_non_king_pieces_are_stunned(game):
         assert not game["board_state"][0][0][0].get("is_stunned", False)
         assert not game["board_state"][0][1][0].get("is_stunned", False)
         assert not game["board_state"][1][1][0].get("is_stunned", False)
+
+
+def test_queen_stun_does_not_affect_neutral_monsters(game):
+    # Place white queen adjacent to a neutral dragon and a black pawn
+    # Move queen next to both — black pawn should be stunned, dragon should not
+    game = clear_game(game)
+
+    game_on_next_turn = copy.deepcopy(game)
+    game_on_next_turn["board_state"][4][7] = [{"type": "neutral_dragon", "health": 5, "turn_spawned": 0}]
+    game_on_next_turn["board_state"][3][5] = [{"type": "black_pawn"}]
+    game_on_next_turn["board_state"][5][7] = [{"type": "white_queen"}]
+    game_state = api.GameStateRequest(**game_on_next_turn)
+    game = api.update_game_state_no_restrictions(game["id"], game_state, Response())
+
+    # Select then move white queen to [4, 6], adjacent to both dragon at [4, 7] and pawn at [3, 5]
+    game = select_and_move_white_piece(game=game, from_row=5, from_col=7, to_row=4, to_col=6)
+
+    # Black pawn should be stunned
+    assert game["board_state"][3][5][0]["type"] == "black_pawn"
+    assert game["board_state"][3][5][0].get("is_stunned", False)
+
+    # Neutral dragon should NOT be stunned
+    dragon = next(p for p in game["board_state"][4][7] if p["type"] == "neutral_dragon")
+    assert not dragon.get("is_stunned", False)
+
+    # Also test with board herald
+    game = clear_game(game)
+
+    game_on_next_turn = copy.deepcopy(game)
+    game_on_next_turn["board_state"][3][0] = [{"type": "neutral_board_herald", "health": 5, "turn_spawned": 0}]
+    game_on_next_turn["board_state"][2][2] = [{"type": "black_pawn"}]
+    game_on_next_turn["board_state"][4][1] = [{"type": "white_queen"}]
+    game_state = api.GameStateRequest(**game_on_next_turn)
+    game = api.update_game_state_no_restrictions(game["id"], game_state, Response())
+
+    # Move queen to [3, 1], adjacent to both herald at [3, 0] and pawn at [2, 2]
+    game = select_and_move_white_piece(game=game, from_row=4, from_col=1, to_row=3, to_col=1)
+
+    # Black pawn should be stunned
+    assert game["board_state"][2][2][0]["type"] == "black_pawn"
+    assert game["board_state"][2][2][0].get("is_stunned", False)
+
+    # Neutral board herald should NOT be stunned
+    herald = next(p for p in game["board_state"][3][0] if p["type"] == "neutral_board_herald")
+    assert not herald.get("is_stunned", False)

--- a/backend/tests/integration/test_api_queen_mechanics.py
+++ b/backend/tests/integration/test_api_queen_mechanics.py
@@ -326,46 +326,35 @@ def test_skip_one_turn_if_all_non_king_pieces_are_stunned(game):
         assert not game["board_state"][1][1][0].get("is_stunned", False)
 
 
-def test_queen_stun_does_not_affect_neutral_monsters(game):
-    # Place white queen adjacent to a neutral dragon and a black pawn
-    # Move queen next to both — black pawn should be stunned, dragon should not
+@pytest.mark.parametrize(
+    "monster_type, monster_pos, pawn_pos, queen_start_pos, queen_end_pos",
+    [
+        ("neutral_dragon", [4, 7], [3, 5], [5, 7], [4, 6]),
+        ("neutral_board_herald", [3, 0], [2, 2], [4, 1], [3, 1]),
+        ("neutral_baron_nashor", [3, 0], [2, 2], [4, 1], [3, 1]),
+    ],
+)
+def test_queen_stun_does_not_affect_neutral_monsters(
+    game, monster_type, monster_pos, pawn_pos, queen_start_pos, queen_end_pos
+):
     game = clear_game(game)
 
     game_on_next_turn = copy.deepcopy(game)
-    game_on_next_turn["board_state"][4][7] = [{"type": "neutral_dragon", "health": 5, "turn_spawned": 0}]
-    game_on_next_turn["board_state"][3][5] = [{"type": "black_pawn"}]
-    game_on_next_turn["board_state"][5][7] = [{"type": "white_queen"}]
+    game_on_next_turn["board_state"][monster_pos[0]][monster_pos[1]] = [{"type": monster_type, "health": 5, "turn_spawned": 0}]
+    game_on_next_turn["board_state"][pawn_pos[0]][pawn_pos[1]] = [{"type": "black_pawn"}]
+    game_on_next_turn["board_state"][queen_start_pos[0]][queen_start_pos[1]] = [{"type": "white_queen"}]
     game_state = api.GameStateRequest(**game_on_next_turn)
     game = api.update_game_state_no_restrictions(game["id"], game_state, Response())
 
-    # Select then move white queen to [4, 6], adjacent to both dragon at [4, 7] and pawn at [3, 5]
-    game = select_and_move_white_piece(game=game, from_row=5, from_col=7, to_row=4, to_col=6)
+    game = select_and_move_white_piece(
+        game=game, from_row=queen_start_pos[0], from_col=queen_start_pos[1], to_row=queen_end_pos[0], to_col=queen_end_pos[1]
+    )
 
     # Black pawn should be stunned
-    assert game["board_state"][3][5][0]["type"] == "black_pawn"
-    assert game["board_state"][3][5][0].get("is_stunned", False)
+    pawn = game["board_state"][pawn_pos[0]][pawn_pos[1]][0]
+    assert pawn["type"] == "black_pawn"
+    assert pawn.get("is_stunned", False)
 
-    # Neutral dragon should NOT be stunned
-    dragon = next(p for p in game["board_state"][4][7] if p["type"] == "neutral_dragon")
-    assert not dragon.get("is_stunned", False)
-
-    # Also test with board herald
-    game = clear_game(game)
-
-    game_on_next_turn = copy.deepcopy(game)
-    game_on_next_turn["board_state"][3][0] = [{"type": "neutral_board_herald", "health": 5, "turn_spawned": 0}]
-    game_on_next_turn["board_state"][2][2] = [{"type": "black_pawn"}]
-    game_on_next_turn["board_state"][4][1] = [{"type": "white_queen"}]
-    game_state = api.GameStateRequest(**game_on_next_turn)
-    game = api.update_game_state_no_restrictions(game["id"], game_state, Response())
-
-    # Move queen to [3, 1], adjacent to both herald at [3, 0] and pawn at [2, 2]
-    game = select_and_move_white_piece(game=game, from_row=4, from_col=1, to_row=3, to_col=1)
-
-    # Black pawn should be stunned
-    assert game["board_state"][2][2][0]["type"] == "black_pawn"
-    assert game["board_state"][2][2][0].get("is_stunned", False)
-
-    # Neutral board herald should NOT be stunned
-    herald = next(p for p in game["board_state"][3][0] if p["type"] == "neutral_board_herald")
-    assert not herald.get("is_stunned", False)
+    # Neutral monster should NOT be stunned
+    monster = next(p for p in game["board_state"][monster_pos[0]][monster_pos[1]] if p["type"] == monster_type)
+    assert not monster.get("is_stunned", False)


### PR DESCRIPTION
## Summary
- **Bug fix:** Queen's stun ability was incorrectly applying to neutral monsters (dragon, board herald, baron nashor). In LoL, neutral monsters are immune to crowd control from champions — this brings the game in line with that behavior.
- **Test:** Added integration test verifying neutral dragon and board herald are not stunned when adjacent to a queen move, while enemy pawns still are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)