### PR TITLE
Add board flash overlay for turn-skip events

### DIFF
--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -55,6 +55,12 @@ const Board = () => {
     }, [])
 
     useEffect(() => {
+        return () => {
+            if (flashTimerRef.current) clearTimeout(flashTimerRef.current)
+        }
+    }, [])
+
+    useEffect(() => {
         if (turnCount <= 0) {
             setPawnExchangePosition(null)
             return

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 
+const BOARD_FLASH_DURATION = 1200
+
 import Background from './Background';
 import Piece from './Piece';
 import PossibleMove from './PossibleMove';
@@ -51,7 +53,7 @@ const Board = () => {
         flashTimerRef.current = setTimeout(() => {
             setBoardFlashClass('')
             setBoardFlashLabel('')
-        }, 1200)
+        }, BOARD_FLASH_DURATION)
     }, [])
 
     useEffect(() => {

--- a/frontend/src/components/Board.js
+++ b/frontend/src/components/Board.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 
 import Background from './Background';
 import Piece from './Piece';
@@ -40,6 +40,19 @@ const Board = () => {
 
     const [shopPieceSelected, setShopPieceSelected] = useState(null)
     const [pawnExchangePosition, setPawnExchangePosition] = useState(null)
+    const [boardFlashClass, setBoardFlashClass] = useState('')
+    const [boardFlashLabel, setBoardFlashLabel] = useState('')
+    const flashTimerRef = useRef(null)
+
+    const handleFlash = useCallback((color, label) => {
+        if (flashTimerRef.current) clearTimeout(flashTimerRef.current)
+        setBoardFlashClass(`board-flash-${color}`)
+        setBoardFlashLabel(label || '')
+        flashTimerRef.current = setTimeout(() => {
+            setBoardFlashClass('')
+            setBoardFlashLabel('')
+        }, 1200)
+    }, [])
 
     useEffect(() => {
         if (turnCount <= 0) {
@@ -229,11 +242,21 @@ const Board = () => {
                         {reconnectMessage}
                     </div>
                 )}
+                {boardFlashClass && (
+                    <div className={boardFlashClass}>
+                        {boardFlashLabel && (
+                            <span className="board-flash-label" style={{
+                                fontSize: `${isMobile ? 4 : 2}vw`,
+                            }}>{boardFlashLabel}</span>
+                        )}
+                    </div>
+                )}
                 </div>
             </div>
             <HUD
                 shopPieceSelected={shopPieceSelected}
                 setShopPieceSelected={setShopPieceSelected}
+                onFlash={handleFlash}
             />
             <CapturedPieces 
                 side={PLAYERS[0]}

--- a/frontend/src/components/HUD.js
+++ b/frontend/src/components/HUD.js
@@ -23,9 +23,10 @@ const HUD = (props) => {
     const prevBishopCaptures = useRef(bishopSpecialCaptures?.length ?? 0)
     const isInitialLoad = useRef(true)
 
-    const triggerFlash = (isPlayerTurn) => {
+    const triggerFlash = (isPlayerTurn, label) => {
         const flashClass = isPlayerTurn ? 'turn-flash-green' : 'turn-flash-red'
         setTurnFlashClass(flashClass)
+        props.onFlash?.(isPlayerTurn ? 'green' : 'red', label)
         const timer = setTimeout(() => setTurnFlashClass(''), 1000)
         return () => clearTimeout(timer)
     }
@@ -46,7 +47,7 @@ const HUD = (props) => {
         const currIsPlayerTurn = turnCount % 2 === 0
 
         if (prevIsPlayerTurn === currIsPlayerTurn) {
-            return triggerFlash(currIsPlayerTurn)
+            return triggerFlash(currIsPlayerTurn, 'Turn Skip')
         }
     }, [turnCount])
 
@@ -56,7 +57,7 @@ const HUD = (props) => {
 
         if (!prev && queenReset) {
             const isPlayerTurn = turnCount % 2 === 0
-            return triggerFlash(isPlayerTurn)
+            return triggerFlash(isPlayerTurn, queenResetType === 'kill' ? 'Queen Kill' : 'Queen Assist')
         }
     }, [queenReset, turnCount])
 
@@ -67,7 +68,7 @@ const HUD = (props) => {
 
         if (currLen > prevLen) {
             const isPlayerTurn = turnCount % 2 === 0
-            return triggerFlash(isPlayerTurn)
+            return triggerFlash(isPlayerTurn, 'Bishop Capture')
         }
     }, [bishopSpecialCaptures, turnCount])
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -253,6 +253,71 @@ progress {
     animation: queen-reset-pulse 0.8s ease-out forwards;
 }
 
+@keyframes board-flash-green {
+    0% { opacity: 0; }
+    10% { opacity: 1; }
+    60% { opacity: 0.8; }
+    100% { opacity: 0; }
+}
+
+@keyframes board-flash-red {
+    0% { opacity: 0; }
+    10% { opacity: 1; }
+    60% { opacity: 0.8; }
+    100% { opacity: 0; }
+}
+
+@keyframes board-flash-label {
+    0% { opacity: 0; transform: scale(0.8); }
+    10% { opacity: 0.9; transform: scale(1.1); }
+    25% { opacity: 0.75; transform: scale(1); }
+    70% { opacity: 0.6; }
+    100% { opacity: 0; transform: scale(1); }
+}
+
+.board-flash-green, .board-flash-red {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 90;
+    pointer-events: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.board-flash-green {
+    background: radial-gradient(
+        ellipse at center,
+        rgba(80, 220, 80, 0.55) 0%,
+        rgba(60, 180, 60, 0.35) 50%,
+        rgba(40, 140, 40, 0.15) 100%
+    );
+    animation: board-flash-green 1.2s ease-out forwards;
+}
+
+.board-flash-red {
+    background: radial-gradient(
+        ellipse at center,
+        rgba(230, 60, 60, 0.55) 0%,
+        rgba(190, 40, 40, 0.35) 50%,
+        rgba(150, 30, 30, 0.15) 100%
+    );
+    animation: board-flash-red 1.2s ease-out forwards;
+}
+
+.board-flash-label {
+    font-family: 'Basic';
+    font-weight: bold;
+    color: white;
+    text-shadow: 0 0 0.8vw rgba(0, 0, 0, 0.7);
+    letter-spacing: 0.15vw;
+    text-transform: uppercase;
+    animation: board-flash-label 1.2s ease-out forwards;
+}
+
 @keyframes reconnect-fade {
     0% { opacity: 0; transform: translate(-50%, -50%) scale(0.9); }
     10% { opacity: 1; transform: translate(-50%, -50%) scale(1); }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -253,14 +253,7 @@ progress {
     animation: queen-reset-pulse 0.8s ease-out forwards;
 }
 
-@keyframes board-flash-green {
-    0% { opacity: 0; }
-    10% { opacity: 1; }
-    60% { opacity: 0.8; }
-    100% { opacity: 0; }
-}
-
-@keyframes board-flash-red {
+@keyframes board-flash {
     0% { opacity: 0; }
     10% { opacity: 1; }
     60% { opacity: 0.8; }
@@ -295,7 +288,7 @@ progress {
         rgba(60, 180, 60, 0.35) 50%,
         rgba(40, 140, 40, 0.15) 100%
     );
-    animation: board-flash-green 1.2s ease-out forwards;
+    animation: board-flash 1.2s ease-out forwards;
 }
 
 .board-flash-red {
@@ -305,7 +298,7 @@ progress {
         rgba(190, 40, 40, 0.35) 50%,
         rgba(150, 30, 30, 0.15) 100%
     );
-    animation: board-flash-red 1.2s ease-out forwards;
+    animation: board-flash 1.2s ease-out forwards;
 }
 
 .board-flash-label {


### PR DESCRIPTION
## Summary
- Adds a colored board flash (green for player, red for enemy) when turn-skip events occur (queen kill/assist, bishop special capture, stun skip)
- Displays centered label text on the board overlay ("Queen Assist", "Queen Kill", "Turn Skip", "Bishop Capture") so players understand why a side gets an extra turn
- HUD notifies Board via `onFlash` callback; no context changes needed

## Test plan
- [x] Trigger a queen kill or assist and verify green/red board flash with "Queen Kill"/"Queen Assist" label
- [x] Trigger a turn skip (all pieces stunned) and verify flash with "Turn Skip" label
- [x] Trigger a bishop special capture and verify flash with "Bishop Capture" label
- [x] Verify no flash occurs on regular turns
- [x] Verify flash also fires during replay mode
- [x] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)